### PR TITLE
fix(infrastructure): two-stage CRD split for clean bootstrap [KAZ-65]

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -1,5 +1,4 @@
 name: Validate Flux Manifests
-
 on:
   pull_request:
     branches: [main]
@@ -8,7 +7,6 @@ on:
       - "platform/**"
       - "apps/**"
       - "clusters/**"
-
 jobs:
   validate:
     name: Validate Kustomize Builds
@@ -18,10 +16,12 @@ jobs:
         # Validate every cluster overlay independently.
         # If any single overlay fails to build, the PR is blocked.
         # Each entry must be a directory containing kustomization.yaml.
-        # Platform uses a two-stage split (CRDs install before policies),
-        # so each stage is validated independently.
+        # Infrastructure and platform both use two-stage splits
+        # (CRDs install before consumers), so each stage is validated independently.
         overlay:
+          - infrastructure/homelab/crds
           - infrastructure/homelab
+          - infrastructure/dev/crds
           - infrastructure/dev
           - platform/homelab/crds
           - platform/homelab/policies
@@ -32,17 +32,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Flux CLI
         uses: fluxcd/flux2/action@main
-
       - name: Validate Kustomize build
         # 'kustomize build' renders the final YAML without applying it.
         # If this fails, the manifests have structural issues.
         run: |
           echo "Validating ${{ matrix.overlay }}..."
           kustomize build ${{ matrix.overlay }}
-
       - name: Validate Kubernetes schemas
         # kubeconform checks that the rendered YAML matches the Kubernetes API schema.
         # It catches things like wrong apiVersion, missing required fields, or
@@ -51,7 +48,6 @@ jobs:
           # Install kubeconform
           curl -sL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
           chmod +x kubeconform
-
           # Build and validate — skip CRDs that kubeconform doesn't know about
           kustomize build ${{ matrix.overlay }} | ./kubeconform \
             -strict \

--- a/clusters/dev/infrastructure.yaml
+++ b/clusters/dev/infrastructure.yaml
@@ -1,10 +1,39 @@
 ---
+# Stage 1: CRD Providers
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-crds
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/dev/crds
+  prune: true
+  wait: true
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: onepassword-operator
+      namespace: onepassword-system
+---
+# Stage 2: CRD Consumers
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infrastructure
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: infrastructure-crds
   interval: 10m
   retryInterval: 1m
   timeout: 5m
@@ -19,10 +48,6 @@ spec:
       kind: Deployment
       name: caddy
       namespace: caddy-system
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: onepassword-operator
-      namespace: onepassword-system
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -1,16 +1,55 @@
 ---
-# Flux Kustomization (capital K) — NOT the same as kustomize.config.k8s.io.
-# This is a Flux CRD that tells the kustomize-controller:
-#   "Build the Kustomize overlay at this path and apply the result to the cluster."
+# Stage 1: CRD Providers
+# Deploys HelmReleases that install Custom Resource Definitions.
+# Must complete before stage 2, which creates resources of those types.
 #
-# The dependency chain: infrastructure → platform → apps
-# Infrastructure has no dependsOn — it deploys first.
+# This is the same pattern used for platform-crds → platform.
+# Flux Kustomizations are atomic — if any resource fails server-side
+# dry-run, the entire batch is rejected. Separating CRD providers
+# from CRD consumers ensures a clean bootstrap from scratch.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: infrastructure-crds
+  namespace: flux-system
+spec:
+  interval: 10m
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./infrastructure/homelab/crds
+  prune: true
+  wait: true
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: onepassword-operator
+      namespace: onepassword-system
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: metallb
+      namespace: metallb-system
+---
+# Stage 2: CRD Consumers
+# Deploys resources that depend on CRDs installed by infrastructure-crds:
+#   - OnePasswordItem (1Password Operator CRD)
+#   - IPAddressPool, L2Advertisement (MetalLB CRDs)
+#
+# Dependency chain: infrastructure-crds → infrastructure → platform-crds → platform → apps
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: infrastructure
   namespace: flux-system
 spec:
+  dependsOn:
+    - name: infrastructure-crds
   interval: 10m
   retryInterval: 1m
   timeout: 5m
@@ -20,34 +59,15 @@ spec:
   path: ./infrastructure/homelab
   prune: true
   wait: true
-  # LEARNING NOTE — postBuild.substituteFrom:
-  #   After Kustomize renders the manifests, Flux replaces ${VARIABLE}
-  #   placeholders with values from this ConfigMap. This keeps all
-  #   environment-specific values (domains, IPs, vault names) in one
-  #   place instead of scattered across dozens of YAML files.
-  #
-  #   The ConfigMap is in flux-system namespace — same as this Kustomization.
-  #   Flux reads it directly; it doesn't need to be in the target namespace.
   postBuild:
     substituteFrom:
       - kind: ConfigMap
         name: cluster-vars
-  # Health checks — Flux waits until these resources are healthy
-  # before marking infrastructure as "ready". The platform layer
-  # depends on infrastructure being ready, so these gates matter.
   healthChecks:
     - apiVersion: apps/v1
       kind: Deployment
       name: caddy
       namespace: caddy-system
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: onepassword-operator
-      namespace: onepassword-system
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: metallb
-      namespace: metallb-system
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: truenas-nfs

--- a/infrastructure/dev/crds/kustomization.yaml
+++ b/infrastructure/dev/crds/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # HelmRepositories — no CRD dependencies
+  - ../../base/flux-addons
+  # CRD provider — installs OnePasswordItem CRD
+  - ../../base/onepassword-operator

--- a/infrastructure/dev/kustomization.yaml
+++ b/infrastructure/dev/kustomization.yaml
@@ -1,14 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  # Flux addon resources (HelmRepositories)
-  - ../base/flux-addons
-
-  # Core infrastructure - no MetalLB (Rancher Desktop has built-in LB)
-  - ../base/onepassword-operator
+  # CRD-dependent — Caddy has OnePasswordItem
   - ../base/caddy
-
 patches:
   # Replace base Caddyfile with dev-specific config
   - target:

--- a/infrastructure/homelab/crds/kustomization.yaml
+++ b/infrastructure/homelab/crds/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # HelmRepositories + Image Automation — no CRD dependencies
+  - ../../base/flux-addons
+  # CRD providers — these HelmReleases install the CRDs that
+  # other infrastructure resources depend on.
+  - ../../base/onepassword-operator
+  - ../../base/metallb

--- a/infrastructure/homelab/kustomization.yaml
+++ b/infrastructure/homelab/kustomization.yaml
@@ -1,20 +1,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-
 resources:
-  # Flux addon resources (HelmRepositories + Image Automation)
-  - ../base/flux-addons
-
-  # Core infrastructure components
-  - ../base/onepassword-operator
-  - ../base/metallb
+  # CRD-dependent resources — these all need CRDs installed by
+  # infrastructure-crds (OnePasswordItem from 1Password Operator,
+  # IPAddressPool/L2Advertisement from MetalLB).
   - ../base/caddy
   - ../base/democratic-csi
   - ../base/github-actions-runner
-
-  # Homelab-only resources
+  # MetalLB custom resources — need MetalLB CRDs from infrastructure-crds
   - metallb/patches/ip-pool.yaml
-
 patches:
   # Replace base Caddyfile with homelab-specific config
   - target:
@@ -22,14 +16,12 @@ patches:
       name: caddy-config
       namespace: caddy-system
     path: caddy/patches/caddyfile-patch.yaml
-
   # TrueNAS dataset paths — homelab uses kaz.cloud pool
   - target:
       kind: HelmRelease
       name: truenas-nfs
       namespace: democratic-csi
     path: democratic-csi/patches/nfs-config.yaml
-
   - target:
       kind: HelmRelease
       name: truenas-iscsi


### PR DESCRIPTION
Fixes KAZ-65. Splits infrastructure layer into infrastructure-crds → infrastructure, same pattern as platform-crds → platform. Ensures fresh bootstrap completes without manual CRD installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation pipeline with improved schema checking and multi-stage deployment support.
  * Introduced two-stage deployment flow ensuring critical dependencies are installed before dependent resources.

* **Chores**
  * Expanded validation coverage across infrastructure and platform configurations.
  * Improved health checks and monitoring for deployment stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->