### PR TITLE
fix(infrastructure): two-stage CRD split for clean bootstrap [KAZ-65]

### DIFF
--- a/clusters/dev/kustomization.yaml
+++ b/clusters/dev/kustomization.yaml
@@ -1,0 +1,18 @@
+# ══════════════════════════════════════════════════════════════════
+# Cluster Entry Point — Dev
+# ══════════════════════════════════════════════════════════════════
+#
+# NOTE: When this cluster is bootstrapped with Flux, a flux-system/
+# subdirectory will be created. It MUST be added to the resources
+# list below or Flux will prune itself. See clusters/homelab/ for
+# the pattern.
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Cluster variables ConfigMap — consumed by postBuild.substituteFrom
+  - vars.yaml
+  # Layer definitions (Flux capital-K Kustomizations)
+  - infrastructure.yaml
+  - platform.yaml
+  - apps.yaml

--- a/clusters/homelab/kustomization.yaml
+++ b/clusters/homelab/kustomization.yaml
@@ -1,0 +1,24 @@
+# ══════════════════════════════════════════════════════════════════
+# Cluster Entry Point — Homelab
+# ══════════════════════════════════════════════════════════════════
+#
+# CRITICAL: This file MUST exist and MUST include flux-system/.
+#
+# Without it, Kustomize auto-generates a resource list from
+# top-level .yaml files only — subdirectories are excluded.
+# The flux-system Kustomization (gotk-sync.yaml) points here
+# with prune: true, meaning anything NOT in the build output
+# gets deleted. If flux-system/ isn't listed, Flux treats its
+# own controllers as orphaned resources and prunes itself.
+#
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # Flux GitOps controllers — MUST be included or Flux prunes itself
+  - flux-system
+  # Cluster variables ConfigMap — consumed by postBuild.substituteFrom
+  - vars.yaml
+  # Layer definitions (Flux capital-K Kustomizations)
+  - infrastructure.yaml
+  - platform.yaml
+  - apps.yaml


### PR DESCRIPTION
Fixes KAZ-65. Splits infrastructure layer into infrastructure-crds → infrastructure, same pattern as platform-crds → platform. Ensures fresh bootstrap completes without manual CRD installation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added cluster configuration for Dev environment
  * Added cluster configuration for Homelab environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->