### PR TITLE
fix(caddy): escape envsubst-incompatible comment in Caddyfile [KAZ-68]

### DIFF
--- a/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
+++ b/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
@@ -11,7 +11,7 @@ data:
     # ══════════════════════════════════════════════════════════════
     #
     # All domains use wildcard TLS via Cloudflare DNS-01 challenge.
-    # Variables (${...}) are substituted by Flux postBuild.
+    # Variables like ACME_EMAIL, LAB_DOMAIN etc are substituted by Flux postBuild.
     # {env.CF_API_TOKEN} is a Caddy runtime env var from the
     # cloudflare-api-token Secret mounted in the Caddy deployment.
     #


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified infrastructure configuration documentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->