### PR TITLE
fix(caddy): remove duplicate apiVersion in ConfigMap patch [KAZ-69]

### DIFF
--- a/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
+++ b/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
-apiVersion: v1
 kind: ConfigMap
 metadata:
   name: caddy-config


### PR DESCRIPTION
## Summary
- Removes duplicate `apiVersion: v1` line in `infrastructure/homelab/caddy/patches/caddyfile-patch.yaml`
- This invalid YAML contributes to the Caddy deployment failing during Flux reconciliation

## Context
Flux `infrastructure` kustomization health check fails with:
- `Deployment/caddy-system/caddy status: 'Failed'`
- `PersistentVolumeClaim/caddy-system/caddy-data status: 'Terminating'`

This cascades and blocks all downstream layers (platform-crds → platform → apps).

## Test plan
- [ ] Merge and verify Flux reconciles `infrastructure` successfully
- [ ] Confirm Caddy deployment reaches Ready state

Closes KAZ-69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a duplicate entry in a configuration file to ensure proper formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->