### PR TITLE
fix(1password): use chart-native secret ref instead of valuesFrom [KAZ-71]

### DIFF
--- a/infrastructure/base/onepassword-operator/helm-release.yaml
+++ b/infrastructure/base/onepassword-operator/helm-release.yaml
@@ -20,12 +20,17 @@ spec:
     operator:
       create: true
       authMethod: service-account
-  # The SA token comes from a Kubernetes Secret, NOT from Git.
-  # This is the one "bootstrap" secret that must be created manually
-  # before Flux can deploy this HelmRelease. Once running, it manages
-  # every other secret via OnePasswordItem CRDs.
-  valuesFrom:
-    - kind: Secret
-      name: op-service-account-token
-      valuesKey: token
-      targetPath: operator.serviceAccountToken.value
+      serviceAccountToken:
+        # The chart mounts this Secret directly into the operator pod.
+        # This is the ONE bootstrap secret that must be created manually
+        # before Flux can deploy this HelmRelease:
+        #
+        #   kubectl create secret generic onepassword-service-account-token \
+        #     --namespace onepassword-system \
+        #     --from-literal=token="$(op read 'op://Homelab/1password-operator-service-account/credential')"
+        #
+        # Do NOT set 'value' here — that causes the chart to create a
+        # second secret, which breaks on re-bootstrap when the source
+        # secret (valuesFrom) doesn't exist yet.
+        name: onepassword-service-account-token
+        key: token


### PR DESCRIPTION
## Summary
- Switches the 1Password operator HelmRelease from `valuesFrom` secret injection to the chart's built-in `serviceAccountToken.name/key` reference
- The old `valuesFrom` approach caused the chart to create a duplicate secret, breaking re-bootstrap when the source secret didn't exist yet

## Test plan
- [ ] Verify the 1Password operator pod starts with a single service account token secret
- [ ] Confirm `OnePasswordItem` resources sync secrets correctly after reconciliation
- [ ] Validate no duplicate secrets exist in `onepassword-system` namespace

Closes KAZ-71

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OnePassword operator configuration to use direct service account token references instead of value mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->