### PR TITLE
feat(infrastructure): harden ARC security [KAZ-62]

### DIFF
--- a/infrastructure/base/github-actions-runner/helm-release-controller.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-controller.yaml
@@ -63,3 +63,24 @@ spec:
   #   CRDs if missing AND replace them on upgrade. This is safe for
   #   ARC because the CRDs are backwards-compatible across versions.
   #   Without this, CRD schema updates would be silently skipped.
+  values:
+    # RBAC NOTE — SCOPED BY DEFAULT:
+    #   The controller chart creates a ClusterRole with only the
+    #   permissions needed to manage ARC CRDs (AutoScalingRunnerSet,
+    #   EphemeralRunnerSet, etc.) — NOT cluster-admin.
+    #   Each runner scale set adds a namespace-scoped Role granting
+    #   the controller access to pods/secrets in that namespace only.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 256Mi
+    # Harden the controller pod
+    securityContext:
+      runAsNonRoot: true
+    flags:
+      # Reduce log noise in production; change to "debug" for troubleshooting
+      logLevel: info
+      logFormat: text

--- a/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
@@ -87,6 +87,12 @@ spec:
     # Runner pod spec customisation
     template:
       spec:
+        # Security hardening — runners execute workflow code, so isolate them.
+        # The official runner image runs as UID 1001 (runner user) by default.
+        # readOnlyRootFilesystem is NOT set because the runner writes to
+        # /home/runner/_work/ during job execution.
+        securityContext:
+          runAsNonRoot: true
         # LEARNING NOTE — MULTI-ARCH NODE SCHEDULING:
         #   The ARC runner image (ghcr.io/actions/actions-runner) is amd64-only.
         #   Your cluster has mixed architectures (amd64 control plane + ARM


### PR DESCRIPTION
## Summary
- Add resource limits/requests to ARC controller (100m/128Mi requests, 250m/256Mi limits) to prevent resource exhaustion
- Enable `runAsNonRoot: true` security context on both controller and runner pods to enforce non-root execution
- Set controller log level to `info` (down from default `debug`) to reduce log noise
- Document that ARC uses scoped RBAC by default (NOT cluster-admin)

## Test plan
- [ ] Verify `kubectl kustomize infrastructure/base/github-actions-runner/` renders cleanly
- [ ] Verify `kubectl kustomize infrastructure/homelab/` includes ARC resources
- [ ] Verify `kubectl kustomize infrastructure/dev/` excludes ARC resources
- [ ] Confirm no hardcoded secrets or tokens in any manifests
- [ ] Validate controller pod starts with resource limits and non-root security context
- [ ] Validate runner pods honour `runAsNonRoot: true` (official runner image uses UID 1001)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions runner infrastructure configuration with resource limits (CPU: 250m, Memory: 256Mi) and requests (CPU: 100m, Memory: 128Mi) for improved resource management.
  * Applied security hardening by enforcing non-root execution for runner pods.
  * Adjusted logging configuration for optimized production observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->