### PR TITLE
fix(caddy): add DNS propagation timeout for TLS cert issuance (KAZ-74)

### DIFF
--- a/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
+++ b/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
@@ -24,10 +24,14 @@ data:
     # ── Reusable Snippets ──────────────────────────────────────
 
     # TLS via Cloudflare DNS-01 challenge
+    # propagation_timeout: how long to wait for TXT record to propagate (default 2m, too short)
+    # propagation_delay: initial wait before first propagation check (lets DNS settle)
     (tls-cloudflare) {
       tls {
         dns cloudflare {env.CF_API_TOKEN}
         resolvers 1.1.1.1
+        propagation_timeout 300
+        propagation_delay 30
       }
     }
 
@@ -125,10 +129,6 @@ data:
       import tls-cloudflare
       reverse_proxy http://${HOME_ASSISTANT_HOST}:8123
     }
-
-
-
-
 
 
 


### PR DESCRIPTION
## Summary
- Add `propagation_timeout` (300s) and `propagation_delay` (30s) to the Caddy TLS Cloudflare DNS-01 snippet
- Fixes timeout failures when Caddy attempts ~11 concurrent DNS-01 challenges on startup

## Problem
Caddy was failing to obtain TLS certs for all `*.lab.kazie.co.uk` domains with:
> `timed out waiting for record to fully propagate; verify DNS provider configuration is correct`

Only `test.lab.kazie.co.uk` (the first domain) succeeded. The default 2-minute propagation timeout is too short when multiple DNS-01 challenges race.

## Test plan
- [ ] After merge, Flux reconciles the ConfigMap and restarts Caddy
- [ ] Verify certs are obtained: `kubectl logs -n caddy-system -l app.kubernetes.io/name=caddy`
- [ ] Test `https://test.lab.kazie.co.uk`, `https://truenas.lab.kazie.co.uk`, etc.
- [ ] User to also verify Cloudflare API token has Zone:DNS:Edit for `kazie.co.uk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DNS challenge configuration to improve certificate renewal reliability and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->