### PR TITLE
fix(caddy): Recreate strategy and kubelet DNS hijacking fix (KAZ-74)

### DIFF
--- a/infrastructure/base/caddy/deployment.yaml
+++ b/infrastructure/base/caddy/deployment.yaml
@@ -9,6 +9,12 @@ metadata:
     app.kubernetes.io/managed-by: flux
 spec:
   replicas: 1
+  # Recreate strategy is required because the caddy-data PVC uses
+  # ReadWriteOnce. RollingUpdate creates the new pod before killing the
+  # old one, causing a Multi-Attach deadlock (new pod can't mount the
+  # PVC while the old pod still holds it).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/name: caddy

--- a/packer/scripts/provision-k8s-node.sh
+++ b/packer/scripts/provision-k8s-node.sh
@@ -165,7 +165,33 @@ EOF
 sysctl --system > /dev/null 2>&1 || warn "sysctl apply skipped (OK in chroot/container)"
 ok "sysctl parameters configured"
 
-# ── 6. Raspberry Pi Specific Configuration ──────────────────────────
+# ── 6. Kubelet DNS Configuration ──────────────────────────────────────
+# LEARNING NOTE — WHY A CUSTOM RESOLV.CONF FOR KUBELET:
+#   By default, kubelet reads the node's /etc/resolv.conf and propagates
+#   its search domains into every pod. If the node has `search kazie.co.uk`
+#   (from DHCP or static config), pods inherit it. Combined with a wildcard
+#   DNS record (*.kazie.co.uk → Caddy LB IP), this hijacks ALL external
+#   DNS lookups from pods — e.g. github.com becomes github.com.kazie.co.uk
+#   → resolves to the Caddy IP instead of the real GitHub server.
+#
+#   This breaks Flux (can't pull from GitHub), ACME certificate issuance
+#   (can't reach Let's Encrypt), and any other outbound HTTPS from pods.
+#
+#   The fix: give kubelet a dedicated resolv.conf with only nameserver
+#   entries (no search domains). Pods then get clean DNS:
+#     search <ns>.svc.cluster.local svc.cluster.local cluster.local
+#   without the node's search domain appended.
+log "Configuring kubelet DNS..."
+
+mkdir -p /etc/kubernetes
+cat > /etc/kubernetes/resolv.conf << 'EOF'
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+EOF
+
+ok "Kubelet DNS resolv.conf created (/etc/kubernetes/resolv.conf)"
+
+# ── 7. Raspberry Pi Specific Configuration ─────────────────────────
 # LEARNING NOTE — CGROUP MEMORY ON RASPBERRY PI:
 #   The Raspberry Pi's default kernel boot parameters don't enable the
 #   memory cgroup controller. Kubelet REQUIRES memory cgroups to enforce
@@ -203,7 +229,7 @@ if [ "${NODE_ARCH}" = "arm64" ]; then
     fi
 fi
 
-# ── 7. Cleanup ──────────────────────────────────────────────────────
+# ── 8. Cleanup ──────────────────────────────────────────────────────
 # LEARNING NOTE — WHY CLEAN UP IN A PACKER BUILD:
 #   Packer captures the VM state as a template image. Any temporary files,
 #   apt caches, or logs from the provisioning process are baked into the
@@ -241,6 +267,6 @@ echo ""
 echo "═══════════════════════════════════════════════════"
 echo "  ✅ Provisioning complete"
 echo "  Packages: open-iscsi, nfs-common, 1password-cli, jq"
-echo "  Configs:  kernel modules, sysctl, iscsid enabled"
+echo "  Configs:  kernel modules, sysctl, iscsid, kubelet DNS"
 echo "  Role: ${NODE_ROLE} | Arch: ${NODE_ARCH}"
 echo "═══════════════════════════════════════════════════"


### PR DESCRIPTION
## Summary
- **Caddy Recreate strategy**: Switched from RollingUpdate to Recreate to prevent Multi-Attach PVC deadlocks during rollouts (ReadWriteOnce volume can only be mounted by one pod at a time)
- **Kubelet DNS fix**: Added `/etc/kubernetes/resolv.conf` to Packer golden image — prevents the node's `search kazie.co.uk` from propagating into pods, which combined with wildcard DNS was hijacking all external lookups (Flux, ACME, etc.)

## Test plan
- [x] Caddy pod starts cleanly with valid Let's Encrypt certs
- [x] All 11 domains accessible via HTTPS from browser
- [x] Flux can reach GitHub after kubelet DNS fix
- [ ] Verify Recreate strategy on next Caddy rollout (no PVC deadlock)
- [ ] Verify new nodes provisioned from golden image get `/etc/kubernetes/resolv.conf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Caddy deployment with optimized pod replacement strategy to improve persistent volume management and prevent attachment conflicts.
  * Implemented dedicated DNS configuration for Kubernetes nodes, preventing pods from inheriting node search domains and improving pod network reliability.

* **Chores**
  * Enhanced node provisioning process with improved DNS configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->