### PR TITLE
fix(caddy): null out rollingUpdate to unblock Flux reconciliation (KAZ-76)

### DIFF
--- a/infrastructure/base/caddy/deployment.yaml
+++ b/infrastructure/base/caddy/deployment.yaml
@@ -15,6 +15,7 @@ spec:
   # PVC while the old pod still holds it).
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app.kubernetes.io/name: caddy


### PR DESCRIPTION
## Summary

- Explicitly set `rollingUpdate: null` in the Caddy Deployment to clear stale fields from Flux server-side apply
- The previous KAZ-74 change set `strategy.type: Recreate` but the old `rollingUpdate` fields remained owned by a previous field manager, causing a dry-run validation error that blocked the entire Flux reconciliation chain (`infrastructure` → `platform-crds` → `platform` → `apps`)

## Test plan

- [ ] `flux get kustomizations` — `infrastructure` should become `Ready`
- [ ] `platform-crds`, `platform`, and `apps` should cascade to `Ready`
- [ ] `kubectl get deploy caddy -n caddy-system -o jsonpath='{.spec.strategy}'` — should show `{"type":"Recreate"}` with no `rollingUpdate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for improved infrastructure consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->