### PR TITLE
feat(monitoring): add graphite-exporter for TrueNAS metrics (KAZ-75)

### DIFF
--- a/platform/base/graphite-exporter/helm-release.yaml
+++ b/platform/base/graphite-exporter/helm-release.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: graphite-exporter
+  namespace: monitoring
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: prometheus-graphite-exporter
+      version: "*"          # Lab: always use latest. Pin in production.
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      interval: 1h
+  values:
+    # Expose the Graphite ingestion port (9109) outside the cluster
+    # so TrueNAS can push metrics to it. MetalLB assigns a stable IP.
+    service:
+      type: LoadBalancer

--- a/platform/base/graphite-exporter/kustomization.yaml
+++ b/platform/base/graphite-exporter/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/platform/homelab/crds/alloy/patches/alloy-config-patch.yaml
+++ b/platform/homelab/crds/alloy/patches/alloy-config-patch.yaml
@@ -97,11 +97,13 @@ spec:
           }
 
           // ════════════════════════════════════════════════════════════
-          // Metrics — TrueNAS (external)
+          // Metrics — TrueNAS (via graphite-exporter)
           // ════════════════════════════════════════════════════════════
+          // TrueNAS pushes Graphite plaintext to graphite-exporter:9109.
+          // The exporter converts to Prometheus format on :9108/metrics.
           prometheus.scrape "truenas" {
             targets = [{
-              __address__ = "${TRUENAS_HOST}:9273",
+              __address__ = "graphite-exporter-prometheus-graphite-exporter.monitoring.svc.cluster.local:9108",
             }]
             scrape_interval = "60s"
             clustering {

--- a/platform/homelab/crds/kustomization.yaml
+++ b/platform/homelab/crds/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../base/kyverno
   - ../../base/grafana-alloy
   - ../../base/kube-state-metrics
+  - ../../base/graphite-exporter
 patches:
   - target:
       kind: HelmRelease


### PR DESCRIPTION
## Summary

- Deploy `prometheus-graphite-exporter` via HelmRelease from prometheus-community chart repo
- Exposes a LoadBalancer Service so TrueNAS can push Graphite plaintext metrics to port 9109
- Update Alloy River config to scrape the exporter's Prometheus endpoint on port 9108 instead of TrueNAS directly
- TrueNAS doesn't expose a Prometheus endpoint natively, so graphite-exporter acts as a Graphite→Prometheus translator

## Test plan

- [ ] `flux get helmreleases -n monitoring` — `graphite-exporter` should be `Ready`
- [ ] `kubectl get svc -n monitoring` — graphite-exporter Service has a MetalLB external IP
- [ ] Configure TrueNAS Graphite exporter: Destination IP = MetalLB IP, Port = 9109
- [ ] `kubectl logs -n monitoring -l app.kubernetes.io/name=alloy --tail=50` — shows scrape of graphite-exporter
- [ ] Grafana Cloud Explore — TrueNAS metrics arriving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Graphite exporter for enhanced metrics collection from TrueNAS systems.
  * Updated metrics pipeline configuration to route TrueNAS metrics through the exporter, improving monitoring and observability capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->