### PR TITLE
fix(caddy): switch PVC to ReadWriteMany to prevent Multi-Attach deadlocks (KAZ-77)

### DIFF
--- a/infrastructure/base/caddy/pvc.yaml
+++ b/infrastructure/base/caddy/pvc.yaml
@@ -9,8 +9,9 @@
 #   - There's a brief TLS downtime while new certs are issued
 #
 #   With a PVC, certs survive restarts, rescheduling, and upgrades.
-#   NFS is fine here — Caddy only needs ReadWriteOnce for /data
-#   and the I/O is minimal (just cert storage, not serving).
+#   NFS supports ReadWriteMany, which prevents Multi-Attach errors
+#   when the pod reschedules to a different node. RWO caused a
+#   cascade: stale VolumeAttachment → CSI lock → TrueNAS overload.
 # ══════════════════════════════════════════════════════════════════
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -23,7 +24,7 @@ metadata:
     app.kubernetes.io/managed-by: flux
 spec:
   accessModes:
-    - ReadWriteOnce
+    - ReadWriteMany
   # Uses the default StorageClass (truenas-nfs)
   # democratic-csi will auto-create a ZFS dataset on TrueNAS
   # and configure NFS sharing — zero manual steps.


### PR DESCRIPTION
## Summary

- Change Caddy PVC `accessModes` from `ReadWriteOnce` to `ReadWriteMany`
- NFS natively supports RWX — no StorageClass changes needed
- Prevents the Multi-Attach → stale VolumeAttachment → CSI lock → TrueNAS overload cascade

## Post-merge manual step

Kubernetes doesn't allow editing `accessModes` on a live PVC. After merge, run on the cluster:

```bash
# Scale down Caddy to release the PVC
kubectl scale deploy caddy -n caddy-system --replicas=0

# Delete the old PVC (the NFS data on TrueNAS is preserved)
kubectl delete pvc caddy-data -n caddy-system

# Flux will reconcile and recreate the PVC with RWX, then the deployment scales back up
flux reconcile kustomization infrastructure
```

## Test plan

- [ ] Run the post-merge commands above
- [ ] `kubectl get pvc caddy-data -n caddy-system` — shows `ReadWriteMany`
- [ ] `kubectl get pods -n caddy-system` — Caddy pod Running
- [ ] Verify Caddy serves HTTPS (e.g. `curl https://lab.kazie.co.uk`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage configuration to prevent volume attachment issues and system overload in multi-node environments. Storage can now be accessed by multiple nodes simultaneously, enhancing system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->