### PR TITLE
fix(packer): migrate to boot_iso block and op run secret injection (KAZ-72)

### DIFF
--- a/packer/.env.packer
+++ b/packer/.env.packer
@@ -1,0 +1,1 @@
+PKR_VAR_proxmox_api_token_secret=op://Homelab/proxmox-packer-token/credential

--- a/packer/README.md
+++ b/packer/README.md
@@ -103,21 +103,19 @@ packer init arm-debian/
 
 ```bash
 cp variables.auto.pkrvars.hcl.example variables.auto.pkrvars.hcl
-# Edit with your Proxmox API token
+# Edit with your Proxmox connection details (non-secret values)
 ```
 
-Or inject from 1Password (recommended):
-
-```bash
-export PKR_VAR_proxmox_api_token_secret=$(op read "op://Homelab/proxmox-packer-token/credential")
-```
+The API token secret is injected at runtime via 1Password CLI — not stored in
+any file. The `.env.packer` file contains an `op://` reference (a pointer, not
+a secret) that `op run` resolves at execution time.
 
 ### 3. Validate
 
 ```bash
-packer validate -var-file="variables.auto.pkrvars.hcl" proxmox-ubuntu/
-packer validate -var-file="variables.auto.pkrvars.hcl" proxmox-debian/
-packer validate -var-file="variables.auto.pkrvars.hcl" proxmox-gpu/
+op run --env-file=packer/.env.packer -- packer validate -var-file=variables.auto.pkrvars.hcl proxmox-ubuntu/
+op run --env-file=packer/.env.packer -- packer validate -var-file=variables.auto.pkrvars.hcl proxmox-debian/
+op run --env-file=packer/.env.packer -- packer validate -var-file=variables.auto.pkrvars.hcl proxmox-gpu/
 packer validate arm-debian/  # Pi build uses defaults, no Proxmox vars needed
 ```
 
@@ -125,9 +123,9 @@ packer validate arm-debian/  # Pi build uses defaults, no Proxmox vars needed
 
 ```bash
 # Build one template at a time (they use different VM IDs so won't conflict)
-packer build -var-file="variables.auto.pkrvars.hcl" proxmox-ubuntu/
-packer build -var-file="variables.auto.pkrvars.hcl" proxmox-debian/
-packer build -var-file="variables.auto.pkrvars.hcl" proxmox-gpu/
+op run --env-file=packer/.env.packer -- packer build -var-file=variables.auto.pkrvars.hcl proxmox-ubuntu/
+op run --env-file=packer/.env.packer -- packer build -var-file=variables.auto.pkrvars.hcl proxmox-debian/
+op run --env-file=packer/.env.packer -- packer build -var-file=variables.auto.pkrvars.hcl proxmox-gpu/
 
 # Pi image (runs on build host, not Proxmox)
 sudo packer build arm-debian/

--- a/packer/proxmox-debian/debian-k8s.pkr.hcl
+++ b/packer/proxmox-debian/debian-k8s.pkr.hcl
@@ -129,7 +129,10 @@ source "proxmox-iso" "debian-k8s" {
   template_description = var.template_description
 
   # ISO
-  iso_file = "${var.proxmox_iso_storage}:iso/${var.debian_iso_file}"
+  boot_iso {
+    iso_file = "${var.proxmox_iso_storage}:iso/${var.debian_iso_file}"
+    unmount  = true
+  }
 
   # Hardware
   cores    = var.vm_cores

--- a/packer/proxmox-gpu/gpu-k8s.pkr.hcl
+++ b/packer/proxmox-gpu/gpu-k8s.pkr.hcl
@@ -154,7 +154,10 @@ source "proxmox-iso" "gpu-k8s" {
   template_description = var.template_description
 
   # ISO — same Ubuntu ISO as the non-GPU template
-  iso_file = "${var.proxmox_iso_storage}:iso/${var.ubuntu_iso_file}"
+  boot_iso {
+    iso_file = "${var.proxmox_iso_storage}:iso/${var.ubuntu_iso_file}"
+    unmount  = true
+  }
 
   # Hardware — larger than regular nodes for build process
   cores    = var.vm_cores

--- a/packer/proxmox-ubuntu/ubuntu-k8s.pkr.hcl
+++ b/packer/proxmox-ubuntu/ubuntu-k8s.pkr.hcl
@@ -179,7 +179,10 @@ source "proxmox-iso" "ubuntu-k8s" {
   template_description = var.template_description
 
   # ISO
-  iso_file = "${var.proxmox_iso_storage}:iso/${var.ubuntu_iso_file}"
+  boot_iso {
+    iso_file = "${var.proxmox_iso_storage}:iso/${var.ubuntu_iso_file}"
+    unmount  = true
+  }
 
   # Hardware
   cores    = var.vm_cores

--- a/packer/variables.auto.pkrvars.hcl.example
+++ b/packer/variables.auto.pkrvars.hcl.example
@@ -17,15 +17,15 @@
 #     4. -var-file flag on command line
 #     5. -var flag on command line
 #
-#   For secrets, prefer environment variables or 1Password CLI injection:
-#     export PKR_VAR_proxmox_api_token_secret=$(op read "op://Homelab/proxmox-packer-token/credential")
+#   For secrets, use 1Password CLI injection via op run:
+#     op run --env-file=.env.packer -- packer build -var-file=variables.auto.pkrvars.hcl proxmox-gpu/
 
 # ── Proxmox Connection ─────────────────────────────────────────────
 proxmox_api_url          = "https://10.2.0.159:8006/api2/json"
 proxmox_api_token_id     = "packer@pve!packer-token"
-proxmox_api_token_secret = "7db6eb10-1aaf-422a-9d06-503be466ad51"
+# proxmox_api_token_secret — injected via `op run --env-file=.env.packer`
 proxmox_node             = "pve"
-c
+
 # ── Storage ─────────────────────────────────────────────────────────
 proxmox_iso_storage  = "nas-1"
 proxmox_disk_storage = "nas-1"


### PR DESCRIPTION
## Summary
- Replace deprecated `iso_file` with `boot_iso` block in all 3 Proxmox templates (ubuntu, debian, gpu)
- Switch from hardcoded Proxmox API token to 1Password `op run` secret injection
- Create `packer/.env.packer` with `op://` reference (safe to commit)
- Remove hardcoded token from `variables.auto.pkrvars.hcl.example`
- Update README with `op run` usage for validate/build commands

## Advisory
Consider rotating the Proxmox API token — the old value was previously committed to git history.

## Test plan
- [x] `packer validate` passes on all 3 Proxmox templates (zero warnings)
- [x] `.env.packer` has correct `op://` reference format
- [x] No hardcoded secrets in any committed file
- [x] HCL syntax consistent across all templates
- [x] Senior review against latest Packer Proxmox plugin docs — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated VM build process to use 1Password CLI for secure secret management at runtime instead of file-based tokens

* **Chores**
  * Modified ISO boot configuration across VM build templates
  * Enhanced environment variable security handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->