### PR TITLE
feat(ci): post-deploy health check with auto-rollback (KAZ-79)

### DIFF
--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -1,0 +1,111 @@
+name: Post-Deploy Health Check
+on:
+  push:
+    branches: [main]
+    paths:
+      - "infrastructure/**"
+      - "platform/**"
+      - "apps/**"
+      - "clusters/**"
+
+concurrency:
+  group: post-deploy-check
+  cancel-in-progress: true
+
+jobs:
+  health-check:
+    name: Cluster Health Check
+    runs-on: homelab
+    if: "!startsWith(github.event.head_commit.message, 'Revert \"')"
+    steps:
+      - name: Install Flux CLI
+        run: curl -s https://fluxcd.io/install.sh | FLUX_VERSION=2.4.0 bash
+
+      - name: Trigger source reconciliation
+        run: flux reconcile source git flux-system --timeout=2m
+
+      - name: Wait for Kustomizations
+        run: |
+          echo "Waiting for all Kustomizations to reconcile..."
+          for i in $(seq 1 60); do
+            NOT_READY=$(flux get kustomizations --no-header | grep -v "True" || true)
+            if [ -z "$NOT_READY" ]; then
+              echo "All Kustomizations are Ready"
+              flux get kustomizations
+              exit 0
+            fi
+            echo "Attempt $i/60 — waiting 10s..."
+            echo "$NOT_READY"
+            sleep 10
+          done
+          echo "TIMEOUT: Kustomizations not ready after 10 minutes"
+          flux get kustomizations
+          exit 1
+
+      - name: Wait for HelmReleases
+        run: |
+          echo "Waiting for all HelmReleases to reconcile..."
+          for i in $(seq 1 60); do
+            NOT_READY=$(flux get helmreleases -A --no-header | grep -v "True" || true)
+            if [ -z "$NOT_READY" ]; then
+              echo "All HelmReleases are Ready"
+              flux get helmreleases -A
+              exit 0
+            fi
+            echo "Attempt $i/60 — waiting 10s..."
+            echo "$NOT_READY"
+            sleep 10
+          done
+          echo "TIMEOUT: HelmReleases not ready after 10 minutes"
+          flux get helmreleases -A
+          exit 1
+
+      - name: Verify critical pods
+        run: |
+          echo "Checking for unhealthy pods..."
+          FAILED=$(kubectl get pods -A --no-headers \
+            --field-selector=status.phase!=Running,status.phase!=Succeeded \
+            | grep -v "Completed" || true)
+          if [ -n "$FAILED" ]; then
+            echo "WARNING: Unhealthy pods detected:"
+            echo "$FAILED"
+            # Don't fail on pod issues — Flux readiness is the primary gate
+            # Pods in CrashLoopBackOff may be pre-existing
+          fi
+          echo "Pod status summary:"
+          kubectl get pods -A --no-headers | awk '{print $4}' | sort | uniq -c | sort -rn
+
+  rollback:
+    name: Auto Rollback
+    needs: health-check
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Revert commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git revert HEAD --no-edit
+          git push origin main
+
+      - name: Create issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const sha = '${{ github.sha }}'.substring(0, 7);
+            const run = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Auto-rollback: commit ${sha} failed health check`,
+              body: `## What happened\n\nCommit ${sha} was automatically reverted because the post-deploy health check failed.\n\n**Reverted commit:** ${{ github.sha }}\n**Author:** @${{ github.event.head_commit.author.username }}\n**Message:** ${{ github.event.head_commit.message }}\n**Health check run:** ${run}\n\n## Next steps\n\n1. Check the [workflow run](${run}) logs to understand what failed\n2. Fix the issue on a branch\n3. Open a new PR`,
+              labels: ['auto-rollback']
+            });

--- a/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
@@ -87,6 +87,7 @@ spec:
     # Runner pod spec customisation
     template:
       spec:
+        serviceAccountName: arc-runner-flux-reader
         # Security hardening — runners execute workflow code, so isolate them.
         # The official runner image runs as UID 1001 (runner user) by default.
         # readOnlyRootFilesystem is NOT set because the runner writes to

--- a/infrastructure/base/github-actions-runner/kustomization.yaml
+++ b/infrastructure/base/github-actions-runner/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - onepassword-item.yaml
   - helm-release-controller.yaml
   - helm-release-runner-set.yaml
+  - rbac-flux-reader.yaml

--- a/infrastructure/base/github-actions-runner/rbac-flux-reader.yaml
+++ b/infrastructure/base/github-actions-runner/rbac-flux-reader.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: arc-runner-flux-reader
+  namespace: arc-runners
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: flux-reader
+rules:
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["gitrepositories"]
+    verbs: ["get", "list", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: arc-runner-flux-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flux-reader
+subjects:
+  - kind: ServiceAccount
+    name: arc-runner-flux-reader
+    namespace: arc-runners


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs after every merge to `main` (on `infrastructure/`, `platform/`, `apps/`, `clusters/` paths)
- Validates Flux reconciliation: waits for all Kustomizations and HelmReleases to reach Ready state (10m timeout each)
- On failure, automatically reverts the commit from `ubuntu-latest` and opens a GitHub issue with details
- Anti-loop: commits starting with `Revert "` skip the workflow entirely
- Adds RBAC (ServiceAccount + ClusterRole + ClusterRoleBinding) for ARC runner pods to read Flux resources and trigger reconciliation

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/post-deploy-check.yaml` | New workflow |
| `infrastructure/base/github-actions-runner/rbac-flux-reader.yaml` | New RBAC resources |
| `infrastructure/base/github-actions-runner/kustomization.yaml` | Add RBAC resource reference |
| `infrastructure/base/github-actions-runner/helm-release-runner-set.yaml` | Set runner ServiceAccount |

## Test plan

- [ ] `flux-validate` workflow passes on this PR (kustomize build)
- [ ] After merge, `Post-Deploy Health Check` workflow triggers on `homelab` runner
- [ ] Verify RBAC: `kubectl auth can-i list kustomizations.kustomize.toolkit.fluxcd.io --as=system:serviceaccount:arc-runners:arc-runner-flux-reader` → yes
- [ ] Health check passes when cluster is healthy
- [ ] (Optional) Test rollback with a deliberately broken manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)