### PR TITLE
feat(platform): deploy Backstage IDP via Flux (KAZ-80)

### DIFF
--- a/clusters/homelab/vars.yaml
+++ b/clusters/homelab/vars.yaml
@@ -49,6 +49,7 @@ data:
   OP_ITEM_CLOUDFLARE: "cloudflare dns API Credentials"
   OP_ITEM_TRUENAS: "Truenas API Credential"
   OP_ITEM_GRAFANA_CLOUD: "grafana-cloud-credentials"
+  OP_ITEM_BACKSTAGE_DB: "backstage-postgresql"
   # ── Grafana Cloud Configuration ────────────────────────────────
   GRAFANA_PROMETHEUS_URL: "https://prometheus-prod-55-prod-gb-south-1.grafana.net/api/prom/push"
   GRAFANA_PROMETHEUS_USERNAME: "2972580"

--- a/infrastructure/base/flux-addons/helm-repositories.yaml
+++ b/infrastructure/base/flux-addons/helm-repositories.yaml
@@ -88,3 +88,13 @@ spec:
   type: oci
   interval: 24h
   url: oci://ghcr.io/actions/actions-runner-controller-charts
+---
+# Backstage — CNCF developer portal
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: backstage
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://backstage.github.io/charts

--- a/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
+++ b/infrastructure/homelab/caddy/patches/caddyfile-patch.yaml
@@ -131,9 +131,12 @@ data:
       reverse_proxy http://${HOME_ASSISTANT_HOST}:8123
     }
 
-
-
-
+    # ── Backstage IDP ────────────────────────────────────────
+    backstage.${LAB_DOMAIN} {
+      import tls-cloudflare
+      import security-headers
+      reverse_proxy http://backstage.backstage.svc.cluster.local:7007
+    }
 
 
 

--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -1,0 +1,43 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: backstage
+  namespace: backstage
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: backstage
+      version: "*"          # Lab: always use latest. Pin in production.
+      sourceRef:
+        kind: HelmRepository
+        name: backstage
+        namespace: flux-system
+      interval: 1h
+  values:
+    backstage:
+      appConfig:
+        app:
+          title: Kazie Backstage
+          baseUrl: https://backstage.${LAB_DOMAIN}
+        backend:
+          baseUrl: https://backstage.${LAB_DOMAIN}
+          listen:
+            port: 7007
+          database:
+            client: pg
+            connection:
+              host: backstage-postgresql
+              port: 5432
+              user: backstage
+              password: ${POSTGRES_PASSWORD}
+    postgresql:
+      enabled: true
+      auth:
+        username: backstage
+        existingSecret: backstage-postgresql
+        secretKeys:
+          userPasswordKey: password
+      primary:
+        persistence:
+          storageClass: truenas-iscsi

--- a/platform/base/backstage/kustomization.yaml
+++ b/platform/base/backstage/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - onepassword-item.yaml

--- a/platform/base/backstage/namespace.yaml
+++ b/platform/base/backstage/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: backstage
+  labels:
+    app.kubernetes.io/part-of: backstage
+    app.kubernetes.io/managed-by: flux

--- a/platform/base/backstage/onepassword-item.yaml
+++ b/platform/base/backstage/onepassword-item.yaml
@@ -1,0 +1,10 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: backstage-postgresql
+  namespace: backstage
+  labels:
+    app.kubernetes.io/part-of: backstage
+    app.kubernetes.io/managed-by: flux
+spec:
+  itemPath: "vaults/${OP_VAULT}/items/${OP_ITEM_BACKSTAGE_DB}"

--- a/platform/homelab/crds/kustomization.yaml
+++ b/platform/homelab/crds/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ../../base/grafana-alloy
   - ../../base/kube-state-metrics
   - ../../base/graphite-exporter
+  - ../../base/backstage
 patches:
   - target:
       kind: HelmRelease


### PR DESCRIPTION
## Summary
- Adds Backstage Helm chart to the platform layer with built-in PostgreSQL subchart (iSCSI storage)
- Integrates 1Password for PostgreSQL credentials via OnePasswordItem CR
- Configures Caddy reverse proxy for `backstage.lab.kazie.co.uk`
- Adds Backstage HelmRepository to Flux and wires up cluster variables

## New files
- `platform/base/backstage/namespace.yaml` — Backstage namespace
- `platform/base/backstage/helm-release.yaml` — HelmRelease with PostgreSQL subchart
- `platform/base/backstage/onepassword-item.yaml` — 1Password secret sync
- `platform/base/backstage/kustomization.yaml` — Kustomize resources list

## Modified files
- `infrastructure/base/flux-addons/helm-repositories.yaml` — Backstage chart repo
- `platform/homelab/crds/kustomization.yaml` — Add backstage to platform stage 1
- `clusters/homelab/vars.yaml` — `OP_ITEM_BACKSTAGE_DB` variable
- `infrastructure/homelab/caddy/patches/caddyfile-patch.yaml` — Backstage reverse proxy

## Manual prerequisites (before merge)
1. Create 1Password item `backstage-postgresql` in `Homelab` vault with `password` field
2. Create Cloudflare DNS record for `backstage.lab.kazie.co.uk` (or rely on wildcard)

## Test plan
- [ ] `kubectl kustomize platform/homelab/crds` builds successfully
- [ ] CI `flux-validate` workflow passes
- [ ] After merge: Post-Deploy Health Check confirms Backstage HelmRelease reaches Ready
- [ ] `kubectl get pods -n backstage` — Backstage and PostgreSQL pods Running
- [ ] `curl -k https://backstage.lab.kazie.co.uk` — returns Backstage UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Backstage platform deployment to the homelab cluster with PostgreSQL database integration and environment-based domain configuration.

* **Chores**
  * Added Helm repository and installation configuration for Backstage.
  * Configured network routing for Backstage domain access.
  * Added necessary Kubernetes namespace and secrets management resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->