### PR TITLE
feat(infrastructure): deploy Traefik alongside Caddy (KAZ-84)

### DIFF
--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -80,3 +80,7 @@ spec:
       kind: HelmRelease
       name: arc-controller
       namespace: arc-system
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: traefik
+      namespace: traefik-system

--- a/infrastructure/base/flux-addons/helm-repositories.yaml
+++ b/infrastructure/base/flux-addons/helm-repositories.yaml
@@ -98,3 +98,13 @@ metadata:
 spec:
   interval: 24h
   url: https://backstage.github.io/charts
+---
+# Traefik — cloud-native ingress proxy
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: traefik
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://traefik.github.io/charts

--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -1,0 +1,69 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: traefik-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: traefik
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: flux-system
+      interval: 1h
+  install:
+    crds: CreateReplace
+    timeout: 10m
+  upgrade:
+    crds: CreateReplace
+    timeout: 10m
+  values:
+    ports:
+      web:
+        exposedPort: 80
+        http:
+          redirections:
+            entryPoint:
+              to: websecure
+              scheme: https
+      websecure:
+        exposedPort: 443
+        http:
+          tls:
+            enabled: true
+            certResolver: letsencrypt
+            domains:
+              - main: "${LAB_DOMAIN}"
+                sans:
+                  - "*.${LAB_DOMAIN}"
+    certificatesResolvers:
+      letsencrypt:
+        acme:
+          email: "${ACME_EMAIL}"
+          storage: /data/acme.json
+          caServer: https://acme-v02.api.letsencrypt.org/directory
+          dnsChallenge:
+            provider: cloudflare
+            resolvers:
+              - "1.1.1.1:53"
+    persistence:
+      enabled: true
+      existingClaim: traefik-data
+      path: /data
+    service:
+      type: LoadBalancer
+    dnsConfig:
+      options:
+        - name: ndots
+          value: "2"
+    env:
+      - name: CF_DNS_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-token
+            key: credential
+    api:
+      dashboard: true

--- a/infrastructure/base/traefik/kustomization.yaml
+++ b/infrastructure/base/traefik/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - pvc.yaml
+  - onepassword-item.yaml

--- a/infrastructure/base/traefik/namespace.yaml
+++ b/infrastructure/base/traefik/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: traefik-system
+  labels:
+    app.kubernetes.io/part-of: traefik
+    app.kubernetes.io/managed-by: flux

--- a/infrastructure/base/traefik/onepassword-item.yaml
+++ b/infrastructure/base/traefik/onepassword-item.yaml
@@ -1,0 +1,10 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token
+  namespace: traefik-system
+  labels:
+    app.kubernetes.io/part-of: traefik
+    app.kubernetes.io/managed-by: flux
+spec:
+  itemPath: "vaults/${OP_VAULT}/items/${OP_ITEM_CLOUDFLARE}"

--- a/infrastructure/base/traefik/pvc.yaml
+++ b/infrastructure/base/traefik/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: traefik-data
+  namespace: traefik-system
+  labels:
+    app.kubernetes.io/name: traefik
+    app.kubernetes.io/part-of: traefik
+    app.kubernetes.io/managed-by: flux
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/infrastructure/homelab/kustomization.yaml
+++ b/infrastructure/homelab/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   # infrastructure-crds (OnePasswordItem from 1Password Operator,
   # IPAddressPool/L2Advertisement from MetalLB).
   - ../base/caddy
+  - ../base/traefik
   - ../base/democratic-csi
   - ../base/github-actions-runner
   # MetalLB custom resources — need MetalLB CRDs from infrastructure-crds

--- a/platform/base/traefik-config/kustomization.yaml
+++ b/platform/base/traefik-config/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - middleware.yaml
+  - test-ingressroute.yaml

--- a/platform/base/traefik-config/middleware.yaml
+++ b/platform/base/traefik-config/middleware.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: security-headers
+  namespace: traefik-system
+spec:
+  headers:
+    browserXssFilter: true
+    contentTypeNosniff: true
+    frameDeny: true
+    stsIncludeSubdomains: true
+    stsPreload: true
+    stsSeconds: 31536000
+    customFrameOptionsValue: SAMEORIGIN

--- a/platform/base/traefik-config/test-ingressroute.yaml
+++ b/platform/base/traefik-config/test-ingressroute.yaml
@@ -1,0 +1,22 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: test-traefik-dashboard
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`test-traefik.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: api@internal
+          kind: TraefikService
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"

--- a/platform/homelab/crds/kustomization.yaml
+++ b/platform/homelab/crds/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ../../base/kube-state-metrics
   - ../../base/graphite-exporter
   - ../../base/backstage
+  - ../../base/traefik-config
 patches:
   - target:
       kind: HelmRelease


### PR DESCRIPTION
## Summary
- Deploys Traefik as a parallel ingress proxy alongside Caddy to validate TLS, routing, and Flux integration
- Adds `traefik-system` namespace, HelmRelease (with ACME DNS challenge via Cloudflare), PVC, and 1Password secret sync
- Adds `security-headers` Middleware and test IngressRoute (`test-traefik.lab.kazie.co.uk` → dashboard) in `platform-crds` stage
- Adds Traefik HelmRepository and health check to `infrastructure` Flux Kustomization

## Manual prerequisite
- Create Cloudflare DNS A record: `test-traefik.lab.kazie.co.uk` → Traefik's MetalLB IP (`kubectl get svc -n traefik-system` after deploy)

## Test plan
- [x] `kubectl kustomize infrastructure/homelab` renders without error
- [x] `kubectl kustomize platform/homelab/crds` renders without error
- [ ] CI `flux-validate` passes
- [ ] `flux get helmreleases -A` — traefik shows `Ready: True`
- [ ] `kubectl get svc -n traefik-system` — LoadBalancer has MetalLB IP
- [ ] `kubectl get secret cloudflare-api-token -n traefik-system` — 1Password synced
- [ ] `kubectl get middleware,ingressroute -n traefik-system` — CRD resources exist
- [ ] `curl -k https://test-traefik.lab.kazie.co.uk` — returns Traefik dashboard (after DNS record)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Traefik ingress controller with automatic HTTPS/TLS support via Let's Encrypt and Cloudflare DNS challenge integration.
  * Added security headers middleware for enhanced web application protection.
  * Added Traefik dashboard accessible via secure ingress route.

* **Chores**
  * Configured Helm repository and persistent storage for Traefik.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->