### PR TITLE
fix(infrastructure,platform): unblock Traefik and Backstage HelmReleases (KAZ-85)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -55,10 +55,11 @@ spec:
       path: /data
     service:
       type: LoadBalancer
-    dnsConfig:
-      options:
-        - name: ndots
-          value: "2"
+    deployment:
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "2"
     env:
       - name: CF_DNS_API_TOKEN
         valueFrom:

--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -21,6 +21,13 @@ spec:
       # GITHUB_APP_PRIVATE_KEY, GITHUB_APP_WEBHOOK_SECRET
       extraEnvVarsSecrets:
         - backstage-github-app
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi
+        limits:
+          cpu: 1000m
+          memory: 1Gi
       appConfig:
         app:
           title: Kazie Backstage
@@ -68,5 +75,12 @@ spec:
         secretKeys:
           userPasswordKey: password
       primary:
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
         persistence:
           storageClass: truenas-iscsi


### PR DESCRIPTION
## Summary
- **Traefik**: Move `dnsConfig` under `deployment.dnsConfig` — chart v39.x added strict schema validation and `dnsConfig` is no longer a valid root-level value
- **Backstage**: Add CPU/memory resource limits to both the Backstage Deployment and PostgreSQL StatefulSet to satisfy the Kyverno `require-resource-limits` policy

## Root Cause
Both HelmReleases were failing, blocking the entire Flux reconciliation chain:
`infrastructure` -> `platform-crds` -> `platform` -> `apps`

## Test plan
- [ ] `kubectl kustomize` passes for both components
- [ ] After merge: `flux get helmreleases -A` shows both Traefik and Backstage as Ready
- [ ] All Flux Kustomizations reconcile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized DNS configuration handling to improve network resolution performance
  * Enhanced resource allocation with updated CPU and memory limits to improve system stability and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->