### PR TITLE
fix(traefik): add resource limits to satisfy Kyverno policy (KAZ-85)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -55,6 +55,13 @@ spec:
       path: /data
     service:
       type: LoadBalancer
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
     deployment:
       dnsConfig:
         options:


### PR DESCRIPTION
## Summary
- Add CPU/memory resource limits to Traefik Deployment to satisfy Kyverno `require-resource-limits` policy
- Traefik was blocked by the same policy as Backstage, preventing the entire infrastructure Kustomization from reconciling

## Context
Follow-up to #42 which fixed the `dnsConfig` schema error — after that resolved, the Kyverno policy block was revealed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)