### PR TITLE
fix(arc-runner): add runAsUser to resolve non-root verification (KAZ-85)

### DIFF
--- a/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
@@ -107,6 +107,7 @@ spec:
         # /home/runner/_work/ during job execution.
         securityContext:
           runAsNonRoot: true
+          runAsUser: 1001
         # LEARNING NOTE — MULTI-ARCH NODE SCHEDULING:
         #   The ARC runner image (ghcr.io/actions/actions-runner) is amd64-only.
         #   Your cluster has mixed architectures (amd64 control plane + ARM


### PR DESCRIPTION
## Summary
- Add `runAsUser: 1001` to the ARC runner pod security context
- The `ghcr.io/actions/actions-runner:latest` image defines its user as string `runner`, not a numeric UID
- Kubernetes cannot verify `runAsNonRoot: true` without a numeric UID, causing `CreateContainerConfigError`
- This is blocking all post-deploy health checks (runner pod can't start)

## Test plan
- [ ] Runner pod starts successfully
- [ ] Post-deploy health check completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)