### PR TITLE
fix(backstage): inject PostgreSQL password from secret and increase timeouts (KAZ-85)

### DIFF
--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -14,6 +14,10 @@ spec:
         name: backstage
         namespace: flux-system
       interval: 1h
+  install:
+    timeout: 10m
+  upgrade:
+    timeout: 10m
   values:
     backstage:
       # 1Password item "backstage-github-app" fields must be named exactly:
@@ -21,6 +25,12 @@ spec:
       # GITHUB_APP_PRIVATE_KEY, GITHUB_APP_WEBHOOK_SECRET
       extraEnvVarsSecrets:
         - backstage-github-app
+      extraEnvVars:
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: backstage-postgresql
+              key: password
       podSecurityContext:
         runAsNonRoot: true
         runAsUser: 1000
@@ -55,7 +65,7 @@ spec:
               host: backstage-postgresql
               port: 5432
               user: backstage
-              password: ${POSTGRES_PASSWORD}
+              password: $${POSTGRES_PASSWORD}
         integrations:
           github:
             - host: github.com


### PR DESCRIPTION
## Summary
- Fix `POSTGRES_PASSWORD` — was an undefined Flux variable causing `client password must be a string` error
- Inject password via `extraEnvVars` with `secretKeyRef` from `backstage-postgresql` secret
- Use `$${POSTGRES_PASSWORD}` Flux escaping so Backstage reads from env at runtime
- Increase install/upgrade timeout to 10m for PostgreSQL PVC provisioning

## Test plan
- [ ] Backstage connects to PostgreSQL successfully
- [ ] Backstage readiness probe returns 200
- [ ] HelmRelease reaches Ready state
- [ ] All Kustomizations reconcile
- [ ] Post-deploy health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)