### PR TITLE
feat(traefik): add IngressRoutes for all services (KAZ-84)

### DIFF
--- a/platform/base/traefik-config/external-services.yaml
+++ b/platform/base/traefik-config/external-services.yaml
@@ -1,0 +1,103 @@
+# ══════════════════════════════════════════════════════════════════
+# External Service Definitions for Traefik IngressRoutes
+# ══════════════════════════════════════════════════════════════════
+# Traefik IngressRoutes can only reference Kubernetes Services.
+# For external hosts (TrueNAS, Home Assistant), we create selectorless
+# Services with explicit Endpoints pointing to the external IPs.
+# When adding a new app, add a named port to both the Service AND Endpoints.
+# For in-cluster services in other namespaces (Backstage), we use
+# ExternalName to avoid needing allowCrossNamespace in Traefik.
+# ══════════════════════════════════════════════════════════════════
+
+---
+# ── TrueNAS Host ────────────────────────────────────────────────
+# All TrueNAS apps share the same host IP but use different ports.
+# One Service+Endpoints pair serves all TrueNAS IngressRoutes.
+apiVersion: v1
+kind: Service
+metadata:
+  name: truenas-external
+  namespace: traefik-system
+spec:
+  ports:
+    - name: webui
+      port: 443
+    - name: n8n
+      port: 30109
+    - name: nextcloud
+      port: 30027
+    - name: uptime-kuma
+      port: 31050
+    - name: grafana
+      port: 30037
+    - name: prometheus
+      port: 30104
+    - name: portainer
+      port: 31015
+    - name: playwright
+      port: 30150
+    - name: auth
+      port: 30141
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: truenas-external
+  namespace: traefik-system
+subsets:
+  - addresses:
+      - ip: "${TRUENAS_HOST}"
+    ports:
+      - name: webui
+        port: 443
+      - name: n8n
+        port: 30109
+      - name: nextcloud
+        port: 30027
+      - name: uptime-kuma
+        port: 31050
+      - name: grafana
+        port: 30037
+      - name: prometheus
+        port: 30104
+      - name: portainer
+        port: 31015
+      - name: playwright
+        port: 30150
+      - name: auth
+        port: 30141
+
+---
+# ── Home Assistant ──────────────────────────────────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: home-assistant-external
+  namespace: traefik-system
+spec:
+  ports:
+    - name: http
+      port: 8123
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: home-assistant-external
+  namespace: traefik-system
+subsets:
+  - addresses:
+      - ip: "${HOME_ASSISTANT_HOST}"
+    ports:
+      - name: http
+        port: 8123
+
+---
+# ── Backstage (in-cluster, different namespace) ────────────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: backstage-external
+  namespace: traefik-system
+spec:
+  type: ExternalName
+  externalName: backstage.backstage.svc.cluster.local

--- a/platform/base/traefik-config/ingressroutes.yaml
+++ b/platform/base/traefik-config/ingressroutes.yaml
@@ -1,0 +1,288 @@
+# ══════════════════════════════════════════════════════════════════
+# Traefik IngressRoutes — All Application Routes (KAZ-84)
+# ══════════════════════════════════════════════════════════════════
+# Migrated from Caddy Caddyfile. Each route maps a hostname to a
+# backend service. HTTPS backends use the insecure-skip-verify
+# ServersTransport (self-signed certs on TrueNAS).
+#
+# DNS must point to Traefik's LoadBalancer IP for these to serve.
+# ══════════════════════════════════════════════════════════════════
+
+---
+# ── TrueNAS WebUI ───────────────────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: truenas
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`truenas.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 443
+          scheme: https
+          serversTransport: insecure-skip-verify
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── n8n (TrueNAS App) ──────────────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: n8n
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`n8n.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 30109
+          scheme: https
+          serversTransport: insecure-skip-verify
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Nextcloud (root domain, not lab subdomain) ─────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: nextcloud
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`nc.${DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 30027
+          scheme: https
+          serversTransport: insecure-skip-verify
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${DOMAIN}"
+        sans:
+          - "*.${DOMAIN}"
+
+---
+# ── Uptime Kuma (TrueNAS App, HTTP backend) ────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: uptime-kuma
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`uptime-kuma.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 31050
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Grafana (TrueNAS App, HTTP backend) ────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: grafana
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`grafana.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 30037
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Prometheus (TrueNAS App, HTTP backend) ─────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: prometheus
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`prometheus.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 30104
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Portainer (TrueNAS App) ────────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: portainer
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`portainer.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 31015
+          scheme: https
+          serversTransport: insecure-skip-verify
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Playwright (TrueNAS App) ───────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: playwright
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`playwright.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 30150
+          scheme: https
+          serversTransport: insecure-skip-verify
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Auth Service (TrueNAS App) ─────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: auth
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`auth.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: truenas-external
+          port: 30141
+          scheme: https
+          serversTransport: insecure-skip-verify
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Home Assistant ──────────────────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: home-assistant
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`ha.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: home-assistant-external
+          port: 8123
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"
+
+---
+# ── Backstage IDP ──────────────────────────────────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: backstage
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`backstage.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: backstage-external
+          port: 7007
+      middlewares:
+        - name: security-headers
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${LAB_DOMAIN}"
+        sans:
+          - "*.${LAB_DOMAIN}"

--- a/platform/base/traefik-config/kustomization.yaml
+++ b/platform/base/traefik-config/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - middleware.yaml
+  - servers-transport.yaml
+  - external-services.yaml
   - test-ingressroute.yaml
+  - ingressroutes.yaml

--- a/platform/base/traefik-config/servers-transport.yaml
+++ b/platform/base/traefik-config/servers-transport.yaml
@@ -1,0 +1,9 @@
+# ServersTransport for upstream services using self-signed TLS certificates.
+# Referenced by IngressRoutes that proxy to HTTPS backends (TrueNAS, etc.)
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: insecure-skip-verify
+  namespace: traefik-system
+spec:
+  insecureSkipVerify: true


### PR DESCRIPTION
## Summary
- Add 11 Traefik IngressRoutes migrating all routes currently served by Caddy
- Create `external-services.yaml` with Service+Endpoints for TrueNAS (9 apps) and Home Assistant, plus ExternalName service for Backstage
- Create `servers-transport.yaml` with `insecureSkipVerify` for HTTPS backends (TrueNAS self-signed certs)
- Caddy remains running in parallel — this is Phase 1 of the migration

## Routes Migrated

| Hostname | Backend | Protocol |
|----------|---------|----------|
| `truenas.lab.kazie.co.uk` | TrueNAS WebUI :443 | HTTPS |
| `n8n.lab.kazie.co.uk` | TrueNAS :30109 | HTTPS |
| `nc.kazie.co.uk` | TrueNAS :30027 | HTTPS |
| `uptime-kuma.lab.kazie.co.uk` | TrueNAS :31050 | HTTP |
| `grafana.lab.kazie.co.uk` | TrueNAS :30037 | HTTP |
| `prometheus.lab.kazie.co.uk` | TrueNAS :30104 | HTTP |
| `portainer.lab.kazie.co.uk` | TrueNAS :31015 | HTTPS |
| `playwright.lab.kazie.co.uk` | TrueNAS :30150 | HTTPS |
| `auth.lab.kazie.co.uk` | TrueNAS :30141 | HTTPS |
| `ha.lab.kazie.co.uk` | Home Assistant :8123 | HTTP |
| `backstage.lab.kazie.co.uk` | backstage.backstage.svc:7007 | HTTP |

## After merge — manual steps
1. Update Cloudflare DNS: point `*.lab.kazie.co.uk` and `nc.kazie.co.uk` A records to Traefik's LoadBalancer IP (`10.2.0.202`)
2. Verify all routes via Traefik
3. Phase 2 PR will remove Caddy from infrastructure layer

## Test plan
- [x] `kubectl kustomize platform/homelab/crds` renders without error (12 IngressRoutes, 1 ServersTransport, 2 Endpoints)
- [ ] After merge: Flux reconciles all IngressRoutes
- [ ] After DNS cutover: all services accessible via Traefik
- [ ] Traefik dashboard shows all routes registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized Traefik routing for TrueNAS, Home Assistant, Backstage, n8n, Nextcloud, Grafana, Prometheus, Portainer, auth, uptime monitoring, and developer tools with HTTPS.
  * Support for routing to external hosts and cross-namespace services with automatic TLS provisioning.
  * Added option to allow secure TLS connections to backends that use self-signed or non-validated certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->