### PR TITLE
feat(traefik): remove Caddy from infrastructure layer (KAZ-84)

### DIFF
--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -64,10 +64,6 @@ spec:
       - kind: ConfigMap
         name: cluster-vars
   healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: caddy
-      namespace: caddy-system
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: truenas-nfs

--- a/infrastructure/homelab/kustomization.yaml
+++ b/infrastructure/homelab/kustomization.yaml
@@ -4,19 +4,12 @@ resources:
   # CRD-dependent resources — these all need CRDs installed by
   # infrastructure-crds (OnePasswordItem from 1Password Operator,
   # IPAddressPool/L2Advertisement from MetalLB).
-  - ../base/caddy
   - ../base/traefik
   - ../base/democratic-csi
   - ../base/github-actions-runner
   # MetalLB custom resources — need MetalLB CRDs from infrastructure-crds
   - metallb/patches/ip-pool.yaml
 patches:
-  # Replace base Caddyfile with homelab-specific config
-  - target:
-      kind: ConfigMap
-      name: caddy-config
-      namespace: caddy-system
-    path: caddy/patches/caddyfile-patch.yaml
   # TrueNAS dataset paths — homelab uses kaz.cloud pool
   - target:
       kind: HelmRelease


### PR DESCRIPTION
## Summary
- Remove Caddy deployment from infrastructure layer (`../base/caddy` resource)
- Remove Caddyfile Kustomize patch
- Remove Caddy Deployment health check from `infrastructure.yaml`
- Flux `prune: true` will garbage-collect all Caddy resources (Deployment, Service, ConfigMap, PVC, Namespace) from the cluster

## Context
Phase 2 of Traefik migration. Phase 1 (#57) deployed all IngressRoutes and DNS now points to Traefik's LoadBalancer IP (`10.2.0.202`). All routes verified working through Traefik.

## Test plan
- [x] `kubectl kustomize infrastructure/homelab` renders with 0 Caddy references
- [ ] After merge: Flux prunes Caddy resources from cluster
- [ ] All routes continue working via Traefik

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Caddy deployment from the infrastructure configuration, including deployment health checks and configuration customizations for the homelab setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->