### PR TITLE
feat(backstage): add reverse proxy route template (KAZ-84)

### DIFF
--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -90,6 +90,8 @@ spec:
               target: https://github.com/Diixtra/diixtra-forge/blob/main/platform/base/backstage/templates/pin-helm-version/template.yaml
             - type: url
               target: https://github.com/Diixtra/diixtra-forge/blob/main/platform/base/backstage/templates/create-infra-component/template.yaml
+            - type: url
+              target: https://github.com/Diixtra/diixtra-forge/blob/main/platform/base/backstage/templates/add-reverse-proxy/template.yaml
     postgresql:
       enabled: true
       auth:

--- a/platform/base/backstage/templates/add-reverse-proxy/skeleton/route-${{ values.name }}.yaml
+++ b/platform/base/backstage/templates/add-reverse-proxy/skeleton/route-${{ values.name }}.yaml
@@ -1,0 +1,65 @@
+{%- if values.backendType === 'external-ip' %}
+# Service + Endpoints for external backend at ${{ values.backendIp }}:${{ values.backendPort }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ values.name }}-external
+  namespace: traefik-system
+spec:
+  ports:
+    - name: backend
+      port: ${{ values.backendPort }}
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: ${{ values.name }}-external
+  namespace: traefik-system
+subsets:
+  - addresses:
+      - ip: "${{ values.backendIp }}"
+    ports:
+      - name: backend
+        port: ${{ values.backendPort }}
+---
+{%- endif %}
+{%- if values.backendType === 'cluster-service' %}
+# ExternalName proxy to in-cluster service
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${{ values.name }}-external
+  namespace: traefik-system
+spec:
+  type: ExternalName
+  externalName: ${{ values.backendService }}
+---
+{%- endif %}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ${{ values.name }}
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`${{ values.hostname }}`)
+      kind: Rule
+      services:
+        - name: ${{ values.name }}-external
+          port: ${{ values.backendPort }}
+{%- if values.backendScheme === 'https' %}
+          scheme: https
+          serversTransport: insecure-skip-verify
+{%- endif %}
+{%- if values.securityHeaders %}
+      middlewares:
+        - name: security-headers
+{%- endif %}
+  tls:
+    certResolver: letsencrypt
+    domains:
+      - main: "${{ values.tlsDomain }}"
+        sans:
+          - "*.${{ values.tlsDomain }}"

--- a/platform/base/backstage/templates/add-reverse-proxy/template.yaml
+++ b/platform/base/backstage/templates/add-reverse-proxy/template.yaml
@@ -1,0 +1,153 @@
+apiVersion: scaffolder.backstage.io/v1beta3
+kind: Template
+metadata:
+  name: add-reverse-proxy
+  title: Add Reverse Proxy Route
+  description: Create a Traefik IngressRoute with optional external Service+Endpoints for a new hostname, then open a PR against diixtra-forge.
+  tags:
+    - traefik
+    - ingress
+    - networking
+spec:
+  owner: platform-team
+  type: networking
+
+  parameters:
+    - title: Route Details
+      required:
+        - name
+        - hostname
+      properties:
+        name:
+          title: Route Name
+          type: string
+          description: "Identifier for the route resources (e.g. my-app, wiki)."
+          pattern: "^[a-z][a-z0-9-]*$"
+        hostname:
+          title: Hostname
+          type: string
+          description: "FQDN the route will serve (e.g. wiki.lab.kazie.co.uk)."
+        securityHeaders:
+          title: Security Headers
+          type: boolean
+          description: Apply the security-headers middleware (X-Frame-Options, HSTS, etc.).
+          default: true
+
+    - title: Backend
+      required:
+        - backendType
+        - backendPort
+      properties:
+        backendType:
+          title: Backend Type
+          type: string
+          description: Where the upstream service runs.
+          enum:
+            - external-ip
+            - cluster-service
+          enumNames:
+            - External IP address (e.g. TrueNAS, Home Assistant)
+            - In-cluster Kubernetes Service
+          default: external-ip
+        backendIp:
+          title: Backend IP Address
+          type: string
+          description: "IP address of the external host (e.g. 10.2.0.232)."
+          pattern: "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$"
+          ui:options:
+            hidden: "{{ parameters.backendType !== 'external-ip' }}"
+        backendService:
+          title: Backend Service
+          type: string
+          description: "Full service DNS (e.g. my-app.my-namespace.svc.cluster.local)."
+          ui:options:
+            hidden: "{{ parameters.backendType !== 'cluster-service' }}"
+        backendPort:
+          title: Backend Port
+          type: integer
+          description: Port the backend listens on.
+        backendScheme:
+          title: Backend Protocol
+          type: string
+          description: "Use HTTPS if the backend serves TLS (e.g. self-signed cert)."
+          enum:
+            - http
+            - https
+          default: http
+      dependencies:
+        backendType:
+          oneOf:
+            - properties:
+                backendType:
+                  const: external-ip
+                backendIp:
+                  type: string
+              required:
+                - backendIp
+            - properties:
+                backendType:
+                  const: cluster-service
+                backendService:
+                  type: string
+              required:
+                - backendService
+
+    - title: TLS Certificate
+      properties:
+        tlsDomain:
+          title: TLS Domain
+          type: string
+          description: "Primary domain for the TLS cert. Use lab.kazie.co.uk for *.lab subdomains, or kazie.co.uk for root domain services."
+          enum:
+            - lab.kazie.co.uk
+            - kazie.co.uk
+          default: lab.kazie.co.uk
+
+  steps:
+    - id: fetch-skeleton
+      name: Fetch skeleton
+      action: fetch:template
+      input:
+        url: ./skeleton
+        targetPath: platform/base/traefik-config
+        values:
+          name: ${{ parameters.name }}
+          hostname: ${{ parameters.hostname }}
+          securityHeaders: ${{ parameters.securityHeaders }}
+          backendType: ${{ parameters.backendType }}
+          backendIp: ${{ parameters.backendIp }}
+          backendService: ${{ parameters.backendService }}
+          backendPort: ${{ parameters.backendPort }}
+          backendScheme: ${{ parameters.backendScheme }}
+          tlsDomain: ${{ parameters.tlsDomain }}
+
+    - id: open-pr
+      name: Open Pull Request
+      action: publish:github:pull-request
+      input:
+        repoUrl: github.com?owner=Diixtra&repo=diixtra-forge
+        branchName: backstage/route-${{ parameters.name }}
+        title: "feat(traefik): add route for ${{ parameters.hostname }}"
+        description: |
+          ## Scaffolded by Backstage — Add Reverse Proxy Route
+
+          | Field | Value |
+          |-------|-------|
+          | **Name** | `${{ parameters.name }}` |
+          | **Hostname** | `${{ parameters.hostname }}` |
+          | **Backend Type** | `${{ parameters.backendType }}` |
+          | **Backend** | `${{ parameters.backendIp }}${{ parameters.backendService }}` |
+          | **Port** | `${{ parameters.backendPort }}` |
+          | **Protocol** | `${{ parameters.backendScheme }}` |
+          | **Security Headers** | `${{ parameters.securityHeaders }}` |
+          | **TLS Domain** | `${{ parameters.tlsDomain }}` |
+
+          ### Reviewer checklist
+          - [ ] Add `- route-${{ parameters.name }}.yaml` to `platform/base/traefik-config/kustomization.yaml`
+          - [ ] Verify DNS record exists for `${{ parameters.hostname }}`
+          - [ ] Verify backend is reachable on port `${{ parameters.backendPort }}`
+
+  output:
+    links:
+      - title: Pull Request
+        url: ${{ steps['open-pr'].output.remoteUrl }}


### PR DESCRIPTION
## Summary
- New Backstage scaffolder template: **Add Reverse Proxy Route**
- Simple form: hostname, backend type (external IP or cluster service), port, protocol, security headers, TLS domain
- Generates a single YAML file with IngressRoute + optional Service/Endpoints
- Opens a PR against diixtra-forge with reviewer checklist
- Registered in Backstage catalog locations (4th template)

## Form Fields
| Field | Description |
|-------|-------------|
| Route Name | Identifier for resources (e.g. `wiki`) |
| Hostname | FQDN (e.g. `wiki.lab.kazie.co.uk`) |
| Security Headers | Toggle HSTS, X-Frame-Options, etc. |
| Backend Type | External IP or in-cluster Service |
| Backend IP/Service | IP address or service FQDN |
| Backend Port | Port number |
| Backend Protocol | HTTP or HTTPS (self-signed) |
| TLS Domain | `lab.kazie.co.uk` or `kazie.co.uk` |

## Test plan
- [x] `kubectl kustomize platform/homelab/crds` renders without error
- [ ] Template visible at `https://backstage.lab.kazie.co.uk/create`
- [ ] Fill form → PR created with correct IngressRoute YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Add Reverse Proxy Route" template in Backstage for self-service configuration of reverse proxy routes, supporting external IP and cluster service backends, TLS encryption, security headers, and automatic pull request creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->