### PR TITLE
fix(traefik): correct provider key casing to kubernetesCRD (KAZ-83)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -54,7 +54,7 @@ spec:
       existingClaim: traefik-data
       path: /data
     providers:
-      kubernetescrd:
+      kubernetesCRD:
         allowExternalNameServices: true
     service:
       type: LoadBalancer


### PR DESCRIPTION
## Summary

- Fix Traefik Helm upgrade failure: `providers.kubernetescrd` → `providers.kubernetesCRD`
- Traefik chart v39+ enforces `additionalProperties: false` on the providers schema, rejecting the lowercase key
- This was blocking the entire `infrastructure` kustomization chain, causing post-deploy health check failures and auto-rollbacks

## Root cause

The key was set as `kubernetescrd` (all lowercase) but the Traefik Helm chart schema requires `kubernetesCRD` (camelCase).

## Test plan

- [ ] CI validates kustomize builds
- [ ] Post-deploy health check passes — Traefik HelmRelease becomes Ready
- [ ] All kustomizations reconcile successfully

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Traefik Helm release configuration to use the correct provider naming format, ensuring compatibility with current Traefik specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->