### PR TITLE
fix(backstage): add explicit amd64 platform and nodeSelector (KAZ-83)

### DIFF
--- a/.github/workflows/backstage-build.yaml
+++ b/.github/workflows/backstage-build.yaml
@@ -36,6 +36,8 @@ jobs:
         with:
           context: ./backstage
           push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64
+          provenance: false
           tags: |
             ghcr.io/diixtra/backstage:latest
             ghcr.io/diixtra/backstage:build-${{ github.run_number }}

--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -48,6 +48,8 @@ spec:
           drop:
             - ALL
         readOnlyRootFilesystem: false
+      nodeSelector:
+        kubernetes.io/arch: amd64
       resources:
         requests:
           cpu: 250m


### PR DESCRIPTION
## Summary

- Add `platforms: linux/amd64` and `provenance: false` to Docker build workflow
- Add `nodeSelector: kubernetes.io/arch: amd64` to Backstage HelmRelease
- Fixes `ImagePullBackOff` with error: "no match for platform in manifest: not found"

## Root cause

Docker buildx v0.12+ produces OCI index manifests with provenance attestations by default. The containerd runtime on the cluster couldn't resolve the platform from this manifest format. The cluster also has mixed architecture (amd64 + arm64 Pi nodes), so a nodeSelector ensures Backstage only runs on amd64.

## Test plan

- [ ] CI builds image with explicit platform
- [ ] Post-deploy health check passes
- [ ] Backstage pod starts successfully on amd64 node

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to target the amd64 platform specifically
  * Disabled provenance tracking for Docker builds
  * Configured deployment scheduling to use amd64 architecture nodes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->