### PR TITLE
fix(backstage): build multi-arch image for amd64 and arm64 (KAZ-83)

### DIFF
--- a/.github/workflows/backstage-build.yaml
+++ b/.github/workflows/backstage-build.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -36,6 +39,8 @@ jobs:
         with:
           context: ./backstage
           push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           tags: |
             ghcr.io/diixtra/backstage:latest
             ghcr.io/diixtra/backstage:build-${{ github.run_number }}

--- a/backstage/Dockerfile
+++ b/backstage/Dockerfile
@@ -1,4 +1,5 @@
 # ── Stage 1: Build ────────────────────────────────────────────────
+# Supports linux/amd64 and linux/arm64 via QEMU cross-compilation.
 FROM node:22-bookworm-slim AS build
 
 ENV PYTHON=/usr/bin/python3


### PR DESCRIPTION
## Summary

- Build Backstage image for both `linux/amd64` and `linux/arm64` via QEMU cross-compilation
- Add `provenance: false` to produce simple manifests compatible with all containerd versions
- No nodeSelector needed — Backstage can run on any architecture

## Root cause

The only amd64 worker (`k8-worker-1`) is under disk pressure, evicting all new pods. The cluster has arm64 Pi nodes available. Building multi-arch means Backstage can be scheduled on any node.

## Test plan

- [ ] CI builds multi-arch image (PR validates Dockerfile compiles)
- [ ] Post-deploy health check passes after merge
- [ ] Backstage pod starts on an arm64 Pi node

🤖 Generated with [Claude Code](https://claude.com/claude-code)