### PR TITLE
fix(traefik): add fsGroup for ACME cert storage permissions (KAZ-84)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -67,6 +67,8 @@ spec:
       limits:
         cpu: 500m
         memory: 256Mi
+    podSecurityContext:
+      fsGroup: 65532
     deployment:
       dnsConfig:
         options:


### PR DESCRIPTION
## Summary
- Traefik chart upgrade changed the container user from root to UID 65532 (nonroot)
- The PVC mount `/data/` is still owned by root, so Traefik cannot create `acme.json`
- This causes `permission denied` on startup, making the `letsencrypt` cert resolver fail
- All IngressRoutes report "nonexistent certificate resolver" — every HTTPS route is broken
- Fix: set `podSecurityContext.fsGroup: 65532` so the volume is group-writable

## Test plan
- [ ] Flux reconciles the Traefik HelmRelease successfully
- [ ] `kubectl logs -n traefik-system deployment/traefik` shows no ACME permission errors
- [ ] `acme.json` is created in `/data/`
- [ ] `https://truenas.lab.kazie.co.uk` serves a valid Let's Encrypt certificate
- [ ] Post-deploy health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pod security configuration by implementing filesystem ownership controls for container deployments, improving overall infrastructure security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->