### PR TITLE
fix(traefik): use initContainer for NFS volume permissions (KAZ-84)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -67,9 +67,23 @@ spec:
       limits:
         cpu: 500m
         memory: 256Mi
-    podSecurityContext:
-      fsGroup: 65532
     deployment:
+      initContainers:
+        - name: volume-permissions
+          image: busybox:latest
+          command: ["sh", "-c", "chown -R 65532:65532 /data"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          securityContext:
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
## Summary
- `fsGroup: 65532` (PR #69) doesn't work on NFS volumes — the kernel can't chown NFS mounts
- Replaces `fsGroup` with a busybox initContainer that runs as root to `chown 65532:65532 /data`
- This allows Traefik to create `acme.json` for Let's Encrypt ACME certificate storage
- Includes resource limits on the initContainer for Kyverno compliance

## Test plan
- [ ] Flux reconciles the Traefik HelmRelease
- [ ] `kubectl exec` shows `/data/` owned by `65532:65532`
- [ ] Traefik logs show no ACME permission errors
- [ ] `acme.json` is created and populated
- [ ] `https://truenas.lab.kazie.co.uk` serves a valid Let's Encrypt cert
- [ ] Post-deploy health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)