### PR TITLE
fix(traefik): remove initContainer that conflicts with runAsNonRoot (KAZ-84)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -67,23 +67,9 @@ spec:
       limits:
         cpu: 500m
         memory: 256Mi
+    podSecurityContext:
+      fsGroup: 65532
     deployment:
-      initContainers:
-        - name: volume-permissions
-          image: busybox:latest
-          command: ["sh", "-c", "chown -R 65532:65532 /data"]
-          volumeMounts:
-            - name: data
-              mountPath: /data
-          securityContext:
-            runAsUser: 0
-          resources:
-            requests:
-              cpu: 10m
-              memory: 16Mi
-            limits:
-              cpu: 50m
-              memory: 32Mi
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
## Summary
- PR #75's busybox initContainer with `runAsUser: 0` conflicts with the Traefik chart's default `runAsNonRoot: true` pod security context
- This caused `CreateContainerConfigError` and blocked the Helm upgrade
- NFS volume `/data/` was already chowned to `65532:65532` via manual intervention
- This PR removes the broken initContainer and keeps `fsGroup: 65532`

## Test plan
- [ ] Traefik pod starts without init errors
- [ ] `kubectl logs` shows no ACME permission errors
- [ ] `acme.json` is created and cert obtained from Let's Encrypt
- [ ] `https://truenas.lab.kazie.co.uk` serves valid cert
- [ ] Post-deploy health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)