### PR TITLE
fix(traefik): switch from wildcard to per-hostname certs (KAZ-84)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -35,10 +35,6 @@ spec:
           tls:
             enabled: true
             certResolver: letsencrypt
-            domains:
-              - main: "${LAB_DOMAIN}"
-                sans:
-                  - "*.${LAB_DOMAIN}"
     certificatesResolvers:
       letsencrypt:
         acme:

--- a/platform/base/traefik-config/ingressroutes.yaml
+++ b/platform/base/traefik-config/ingressroutes.yaml
@@ -30,10 +30,6 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── n8n (TrueNAS App) ──────────────────────────────────────────
@@ -57,10 +53,6 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Nextcloud (root domain, not lab subdomain) ─────────────────
@@ -84,10 +76,6 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${DOMAIN}"
-        sans:
-          - "*.${DOMAIN}"
 
 ---
 # ── Uptime Kuma (TrueNAS App, HTTP backend) ────────────────────
@@ -107,10 +95,6 @@ spec:
           port: 31050
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Grafana (TrueNAS App, HTTP backend) ────────────────────────
@@ -130,10 +114,6 @@ spec:
           port: 30037
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Prometheus (TrueNAS App, HTTP backend) ─────────────────────
@@ -153,10 +133,6 @@ spec:
           port: 30104
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Portainer (TrueNAS App) ────────────────────────────────────
@@ -180,10 +156,6 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Playwright (TrueNAS App) ───────────────────────────────────
@@ -207,10 +179,6 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Auth Service (TrueNAS App) ─────────────────────────────────
@@ -234,10 +202,6 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Home Assistant ──────────────────────────────────────────────
@@ -257,10 +221,6 @@ spec:
           port: 8123
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"
 
 ---
 # ── Backstage IDP ──────────────────────────────────────────────
@@ -282,7 +242,3 @@ spec:
         - name: security-headers
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${LAB_DOMAIN}"
-        sans:
-          - "*.${LAB_DOMAIN}"


### PR DESCRIPTION
## Summary
- Remove wildcard `domains` blocks from Traefik HelmRelease entrypoint and all IngressRoutes
- Traefik now auto-detects hostnames from `Host()` match rules and requests individual certs per hostname
- Root cause: Cloudflare wildcard A records (`*.lab.kazie.co.uk`) suppress TXT record resolution for subdomains, breaking DNS-01 ACME challenge for wildcard certs
- Individual certs use `_acme-challenge.<hostname>.lab.kazie.co.uk` (two levels deep), which wildcards can't match

## Test plan
- [ ] Flux reconciles infrastructure and platform kustomizations
- [ ] Traefik pod restarts without errors
- [ ] ACME cert resolver successfully obtains certs (no "propagation: time limit exceeded" errors)
- [ ] `https://truenas.lab.kazie.co.uk` loads with valid Let's Encrypt cert
- [ ] All IngressRoutes serve valid TLS

🤖 Generated with [Claude Code](https://claude.com/claude-code)