### PR TITLE
fix(traefik): remove certResolver from entrypoint-level TLS (KAZ-84)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -34,7 +34,6 @@ spec:
         http:
           tls:
             enabled: true
-            certResolver: letsencrypt
     certificatesResolvers:
       letsencrypt:
         acme:


### PR DESCRIPTION
## Summary
- Remove `certResolver: letsencrypt` from the websecure entrypoint-level TLS config
- Entrypoint-level certResolver was overriding per-hostname cert detection, causing Traefik to still request wildcard certs (`*.lab.kazie.co.uk`)
- Each IngressRoute already specifies `tls.certResolver: letsencrypt`, which Traefik uses with the route's `Host()` matcher to request per-hostname certs

## Test plan
- [ ] Traefik HelmRelease upgrades successfully
- [ ] ACME resolver requests individual certs per hostname (not wildcards)
- [ ] No "propagation: time limit exceeded" errors in Traefik logs
- [ ] Valid Let's Encrypt cert on `https://truenas.lab.kazie.co.uk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)