### PR TITLE
fix(traefik): add ACME DNS challenge delay to avoid negative cache (KAZ-84)

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -42,6 +42,7 @@ spec:
           caServer: https://acme-v02.api.letsencrypt.org/directory
           dnsChallenge:
             provider: cloudflare
+            delayBeforeCheck: "30"
             resolvers:
               - "1.1.1.1:53"
     persistence:


### PR DESCRIPTION
## Summary
- Adds `delayBeforeCheck: "30"` to Traefik's ACME DNS-01 challenge config
- Cloudflare authoritative NS caches NXDOMAIN for `_acme-challenge.*` TXT records
- When lego checks propagation immediately after creation, it hits stale negative cache from prior failures
- 30s delay gives the NS time to serve newly created records, breaking the negative cache cycle

## Root cause analysis
Confirmed via testing:
- Fresh TXT records at `_acme-challenge.<host>.lab.kazie.co.uk` resolve instantly when the name was never queried before
- Previously-queried names return NXDOMAIN even after the record exists in the Cloudflare API
- Each retry refreshes the negative cache, creating a permanent failure loop

## Test plan
- [ ] CI validates Flux manifests
- [ ] After merge + negative cache expiry (~30 min), Traefik obtains Let's Encrypt certs
- [ ] `kubectl logs -n traefik-system deploy/traefik` shows successful ACME challenges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated certificate renewal configuration to include a delay before DNS verification checks. This improvement enhances the reliability of SSL/TLS certificate provisioning for the application infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->