### PR TITLE
feat(external-dns): automatic Cloudflare DNS management (KAZ-84)

### DIFF
--- a/infrastructure/base/external-dns/helm-release.yaml
+++ b/infrastructure/base/external-dns/helm-release.yaml
@@ -1,0 +1,57 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: external-dns
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: external-dns
+      version: "*"
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: flux-system
+      interval: 1h
+  install:
+    timeout: 10m
+  upgrade:
+    timeout: 10m
+  values:
+    provider:
+      name: cloudflare
+    env:
+      - name: CF_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cloudflare-api-token
+            key: credential
+    extraArgs:
+      - --cloudflare-proxied=false
+      - --traefik-disable-legacy
+    sources:
+      - traefik-proxy
+    domainFilters:
+      - kazie.co.uk
+    policy: upsert-only
+    registry: txt
+    txtOwnerId: external-dns
+    txtPrefix: _externaldns.
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65534
+      seccompProfile:
+        type: RuntimeDefault

--- a/infrastructure/base/external-dns/kustomization.yaml
+++ b/infrastructure/base/external-dns/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - onepassword-item.yaml

--- a/infrastructure/base/external-dns/namespace.yaml
+++ b/infrastructure/base/external-dns/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  labels:
+    app.kubernetes.io/part-of: external-dns
+    app.kubernetes.io/managed-by: flux

--- a/infrastructure/base/external-dns/onepassword-item.yaml
+++ b/infrastructure/base/external-dns/onepassword-item.yaml
@@ -1,0 +1,10 @@
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: cloudflare-api-token
+  namespace: external-dns
+  labels:
+    app.kubernetes.io/part-of: external-dns
+    app.kubernetes.io/managed-by: flux
+spec:
+  itemPath: "vaults/${OP_VAULT}/items/${OP_ITEM_CLOUDFLARE}"

--- a/infrastructure/base/flux-addons/helm-repositories.yaml
+++ b/infrastructure/base/flux-addons/helm-repositories.yaml
@@ -99,6 +99,16 @@ spec:
   interval: 24h
   url: https://backstage.github.io/charts
 ---
+# ExternalDNS — automatic DNS record management
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: external-dns
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/external-dns/
+---
 # Traefik — cloud-native ingress proxy
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/infrastructure/homelab/kustomization.yaml
+++ b/infrastructure/homelab/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   # infrastructure-crds (OnePasswordItem from 1Password Operator,
   # IPAddressPool/L2Advertisement from MetalLB).
   - ../base/traefik
+  - ../base/external-dns
   - ../base/democratic-csi
   - ../base/github-actions-runner
   # MetalLB custom resources — need MetalLB CRDs from infrastructure-crds

--- a/platform/base/backstage/templates/add-reverse-proxy/skeleton/route-${{ values.name }}.yaml
+++ b/platform/base/backstage/templates/add-reverse-proxy/skeleton/route-${{ values.name }}.yaml
@@ -59,7 +59,3 @@ spec:
 {%- endif %}
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${{ values.tlsDomain }}"
-        sans:
-          - "*.${{ values.tlsDomain }}"

--- a/platform/base/backstage/templates/add-reverse-proxy/template.yaml
+++ b/platform/base/backstage/templates/add-reverse-proxy/template.yaml
@@ -92,17 +92,6 @@ spec:
               required:
                 - backendService
 
-    - title: TLS Certificate
-      properties:
-        tlsDomain:
-          title: TLS Domain
-          type: string
-          description: "Primary domain for the TLS cert. Use lab.kazie.co.uk for *.lab subdomains, or kazie.co.uk for root domain services."
-          enum:
-            - lab.kazie.co.uk
-            - kazie.co.uk
-          default: lab.kazie.co.uk
-
   steps:
     - id: fetch-skeleton
       name: Fetch skeleton
@@ -119,7 +108,6 @@ spec:
           backendService: ${{ parameters.backendService }}
           backendPort: ${{ parameters.backendPort }}
           backendScheme: ${{ parameters.backendScheme }}
-          tlsDomain: ${{ parameters.tlsDomain }}
 
     - id: open-pr
       name: Open Pull Request
@@ -140,12 +128,11 @@ spec:
           | **Port** | `${{ parameters.backendPort }}` |
           | **Protocol** | `${{ parameters.backendScheme }}` |
           | **Security Headers** | `${{ parameters.securityHeaders }}` |
-          | **TLS Domain** | `${{ parameters.tlsDomain }}` |
 
           ### Reviewer checklist
           - [ ] Add `- route-${{ parameters.name }}.yaml` to `platform/base/traefik-config/kustomization.yaml`
-          - [ ] Verify DNS record exists for `${{ parameters.hostname }}`
           - [ ] Verify backend is reachable on port `${{ parameters.backendPort }}`
+          - [ ] DNS A record will be auto-created by ExternalDNS after merge
 
   output:
     links:


### PR DESCRIPTION
## Summary
- **ExternalDNS**: Deploy kubernetes-sigs/external-dns with Cloudflare provider to automatically create A records for Traefik IngressRoutes
- **Template fix**: Remove wildcard `domains` block from add-reverse-proxy Backstage template (aligning with per-hostname cert approach from PRs #79/#80)
- **DNS automation**: Backstage templates no longer need manual DNS steps — ExternalDNS handles record creation automatically when IngressRoutes are deployed

### ExternalDNS Configuration
| Setting | Value |
|---------|-------|
| Provider | Cloudflare (API token from 1Password) |
| Source | `traefik-proxy` (watches IngressRoute CRDs) |
| Domain filter | `kazie.co.uk` |
| Policy | `upsert-only` (never deletes records) |
| Ownership tracking | TXT records with `_externaldns.` prefix |

### How it works
1. Backstage template creates IngressRoute → PR merged
2. Flux deploys IngressRoute to cluster
3. ExternalDNS detects new `Host()` rule → creates Cloudflare A record
4. Traefik ACME obtains TLS cert via DNS-01 challenge

## Test plan
- [ ] CI validates Flux kustomize builds
- [ ] ExternalDNS pod starts in `external-dns` namespace
- [ ] ExternalDNS creates A records for existing IngressRoutes
- [ ] Verify `external-dns` logs show Cloudflare record creation
- [ ] Backstage template renders correctly without `domains` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic DNS record creation for deployed services using ExternalDNS integration.

* **Chores**
  * Simplified reverse proxy creation workflow by removing manual TLS domain configuration—now automatically handled during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->