### PR TITLE
fix(backstage): remove wildcard TLS from add-reverse-proxy template (KAZ-84)

### DIFF
--- a/platform/base/backstage/templates/add-reverse-proxy/skeleton/route-${{ values.name }}.yaml
+++ b/platform/base/backstage/templates/add-reverse-proxy/skeleton/route-${{ values.name }}.yaml
@@ -59,7 +59,3 @@ spec:
 {%- endif %}
   tls:
     certResolver: letsencrypt
-    domains:
-      - main: "${{ values.tlsDomain }}"
-        sans:
-          - "*.${{ values.tlsDomain }}"

--- a/platform/base/backstage/templates/add-reverse-proxy/template.yaml
+++ b/platform/base/backstage/templates/add-reverse-proxy/template.yaml
@@ -92,17 +92,6 @@ spec:
               required:
                 - backendService
 
-    - title: TLS Certificate
-      properties:
-        tlsDomain:
-          title: TLS Domain
-          type: string
-          description: "Primary domain for the TLS cert. Use lab.kazie.co.uk for *.lab subdomains, or kazie.co.uk for root domain services."
-          enum:
-            - lab.kazie.co.uk
-            - kazie.co.uk
-          default: lab.kazie.co.uk
-
   steps:
     - id: fetch-skeleton
       name: Fetch skeleton
@@ -119,7 +108,6 @@ spec:
           backendService: ${{ parameters.backendService }}
           backendPort: ${{ parameters.backendPort }}
           backendScheme: ${{ parameters.backendScheme }}
-          tlsDomain: ${{ parameters.tlsDomain }}
 
     - id: open-pr
       name: Open Pull Request
@@ -140,12 +128,11 @@ spec:
           | **Port** | `${{ parameters.backendPort }}` |
           | **Protocol** | `${{ parameters.backendScheme }}` |
           | **Security Headers** | `${{ parameters.securityHeaders }}` |
-          | **TLS Domain** | `${{ parameters.tlsDomain }}` |
 
           ### Reviewer checklist
           - [ ] Add `- route-${{ parameters.name }}.yaml` to `platform/base/traefik-config/kustomization.yaml`
-          - [ ] Verify DNS record exists for `${{ parameters.hostname }}`
           - [ ] Verify backend is reachable on port `${{ parameters.backendPort }}`
+          - [ ] DNS A record will be auto-created by ExternalDNS after merge
 
   output:
     links:


### PR DESCRIPTION
## Summary
- Remove wildcard `domains` block from the add-reverse-proxy Backstage template skeleton
- Remove unused TLS domain parameter from the template form
- Aligns with per-hostname cert approach from PRs #79/#80

## Test plan
- [ ] CI validates kustomize builds
- [ ] Template renders IngressRoute with just `certResolver: letsencrypt` (no `domains` block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed TLS domain configuration requirement from reverse proxy setup process
  * DNS A records will now be automatically created by ExternalDNS after deployment, simplifying post-deployment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->