### PR TITLE
fix(platform): add kube-state-metrics resource limits and fix infra timeout

### DIFF
--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -56,7 +56,7 @@ spec:
     - name: infrastructure-crds
   interval: 10m
   retryInterval: 1m
-  timeout: 5m
+  timeout: 10m
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/platform/base/kube-state-metrics/helm-release.yaml
+++ b/platform/base/kube-state-metrics/helm-release.yaml
@@ -14,4 +14,11 @@ spec:
         name: prometheus-community
         namespace: flux-system
       interval: 1h
-  values: {}
+  values:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi


### PR DESCRIPTION
## Summary
- **kube-state-metrics**: Add resource limits (50m-200m CPU, 64Mi-256Mi memory) — was running with `values: {}` (unlimited), violating the `require-resource-limits` Kyverno policy
- **infrastructure Kustomization**: Bump timeout from 5m to 10m to match `infrastructure-crds`, preventing reconciliation failures

## Context
Cluster has been crashing and requiring reboots. While the root cause likely involves TrueNAS (separate VM), these are real issues found during investigation:
1. Unbounded kube-state-metrics is a policy violation and OOM risk on the k3s node
2. Timeout mismatch means stage 2 can fail if stage 1 takes >5m

## Still needs investigation (when cluster is back up)
- TrueNAS system logs for crash cause
- democratic-csi pod logs for iSCSI reconnect storms
- `dmesg` on both k3s node and TrueNAS VM

Ref: KAZ-87

🤖 Generated with [Claude Code](https://claude.com/claude-code)