### PR TITLE
fix(platform): add resource limits to Grafana Alloy

### DIFF
--- a/platform/base/grafana-alloy/helm-release.yaml
+++ b/platform/base/grafana-alloy/helm-release.yaml
@@ -31,3 +31,10 @@ spec:
     alloy:
       configMap:
         create: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi


### PR DESCRIPTION
## Summary
- Add CPU and memory requests/limits to Grafana Alloy DaemonSet
- Alloy runs in the `monitoring` namespace which is subject to the `require-resource-limits` Kyverno policy (enforce mode)
- Values: 50m-500m CPU, 128Mi-512Mi memory — appropriate for a metrics collection DaemonSet

Ref: KAZ-87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation configuration to optimize infrastructure stability and performance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->