### PR TITLE
feat(backstage): wire TeraSky entity page plugins (KAZ-88)

### DIFF
--- a/backstage/packages/app/src/App.tsx
+++ b/backstage/packages/app/src/App.tsx
@@ -1,9 +1,9 @@
 import { Navigate, Route } from 'react-router-dom';
 import {
-  CatalogEntityPage,
   CatalogIndexPage,
   catalogPlugin,
 } from '@backstage/plugin-catalog';
+import { entityPage } from './components/catalog/EntityPage';
 import { ScaffolderPage, scaffolderPlugin } from '@backstage/plugin-scaffolder';
 import { UserSettingsPage } from '@backstage/plugin-user-settings';
 import { Root } from './components/Root';
@@ -17,7 +17,7 @@ import { createApp } from '@backstage/app-defaults';
 import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { githubAuthApiRef } from '@backstage/core-plugin-api';
 import { TechRadarPage } from '@backstage-community/plugin-tech-radar';
-import { PolicyReporterPage } from '@kyverno/backstage-plugin-policy-reporter';
+import { PolicyReportsPage } from '@kyverno/backstage-plugin-policy-reporter';
 import { TemplateBuilderPage } from '@terasky/backstage-plugin-template-builder';
 
 const app = createApp({
@@ -49,13 +49,10 @@ const routes = (
   <FlatRoutes>
     <Route path="/" element={<Navigate to="catalog" />} />
     <Route path="/catalog" element={<CatalogIndexPage />} />
-    <Route
-      path="/catalog/:namespace/:kind/:name"
-      element={<CatalogEntityPage />}
-    />
+    <Route path="/catalog/:namespace/:kind/:name" element={entityPage} />
     <Route path="/create" element={<ScaffolderPage />} />
     <Route path="/tech-radar" element={<TechRadarPage />} />
-    <Route path="/policy-reporter" element={<PolicyReporterPage />} />
+    <Route path="/policy-reporter" element={<PolicyReportsPage />} />
     <Route path="/template-builder" element={<TemplateBuilderPage />} />
     <Route path="/settings" element={<UserSettingsPage />} />
   </FlatRoutes>

--- a/backstage/packages/app/src/components/catalog/EntityPage.tsx
+++ b/backstage/packages/app/src/components/catalog/EntityPage.tsx
@@ -1,0 +1,164 @@
+import { Grid } from '@mui/material';
+import {
+  EntityAboutCard,
+  EntityLayout,
+  EntityLinksCard,
+  EntitySwitch,
+  isKind,
+} from '@backstage/plugin-catalog';
+import {
+  EntityKubernetesContent,
+  isKubernetesAvailable,
+} from '@backstage/plugin-kubernetes';
+import {
+  CrossplaneOverviewCardSelector,
+  CrossplaneResourceGraphSelector,
+  CrossplaneResourcesTableSelector,
+  isCrossplaneAvailable,
+} from '@terasky/backstage-plugin-crossplane-resources-frontend';
+import {
+  KubernetesResourcesPage,
+  isKubernetesResourcesAvailable,
+} from '@terasky/backstage-plugin-kubernetes-resources-frontend';
+import { EntityScaffolderContent } from '@terasky/backstage-plugin-entity-scaffolder-content';
+
+// ---------------------------------------------------------------------------
+// Shared overview content (used by most entity types)
+// ---------------------------------------------------------------------------
+const overviewContent = (
+  <Grid container spacing={3}>
+    <Grid item md={6}>
+      <EntityAboutCard variant="gridItem" />
+    </Grid>
+    <Grid item md={6}>
+      <EntityLinksCard />
+    </Grid>
+  </Grid>
+);
+
+// ---------------------------------------------------------------------------
+// Service / Component entity page
+// ---------------------------------------------------------------------------
+const serviceEntityPage = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      {overviewContent}
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/kubernetes"
+      title="Kubernetes"
+      if={isKubernetesAvailable}
+    >
+      <EntityKubernetesContent />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/kubernetes-resources"
+      title="K8s Resources"
+      if={isKubernetesResourcesAvailable}
+    >
+      <KubernetesResourcesPage />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/crossplane"
+      title="Crossplane"
+      if={isCrossplaneAvailable}
+    >
+      <Grid container spacing={3}>
+        <Grid item md={12}>
+          <CrossplaneOverviewCardSelector />
+        </Grid>
+        <Grid item md={12}>
+          <CrossplaneResourceGraphSelector />
+        </Grid>
+        <Grid item md={12}>
+          <CrossplaneResourcesTableSelector />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+// ---------------------------------------------------------------------------
+// Resource entity page (e.g. kubernetes-cluster, database, s3-bucket)
+// ---------------------------------------------------------------------------
+const resourceEntityPage = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      {overviewContent}
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/kubernetes"
+      title="Kubernetes"
+      if={isKubernetesAvailable}
+    >
+      <EntityKubernetesContent />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/kubernetes-resources"
+      title="K8s Resources"
+      if={isKubernetesResourcesAvailable}
+    >
+      <KubernetesResourcesPage />
+    </EntityLayout.Route>
+
+    <EntityLayout.Route
+      path="/crossplane"
+      title="Crossplane"
+      if={isCrossplaneAvailable}
+    >
+      <Grid container spacing={3}>
+        <Grid item md={12}>
+          <CrossplaneOverviewCardSelector />
+        </Grid>
+        <Grid item md={12}>
+          <CrossplaneResourceGraphSelector />
+        </Grid>
+        <Grid item md={12}>
+          <CrossplaneResourcesTableSelector />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+
+    <EntityLayout.Route path="/scaffolder" title="Actions">
+      <EntityScaffolderContent
+        templateGroupFilters={[
+          {
+            title: 'Actions for this resource',
+            filter: (_entity, template) =>
+              template.metadata.tags?.includes('resource') ?? false,
+          },
+        ]}
+        buildInitialState={(entity, _template) => ({
+          resourceRef: `${entity.kind}:${entity.metadata.namespace ?? 'default'}/${entity.metadata.name}`,
+        })}
+      />
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+// ---------------------------------------------------------------------------
+// Default entity page (fallback for all other entity kinds)
+// ---------------------------------------------------------------------------
+const defaultEntityPage = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      {overviewContent}
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+
+// ---------------------------------------------------------------------------
+// EntityPage — switches layout based on entity kind/type
+// ---------------------------------------------------------------------------
+export const entityPage = (
+  <EntitySwitch>
+    <EntitySwitch.Case if={isKind('component')} children={serviceEntityPage} />
+    <EntitySwitch.Case if={isKind('resource')} children={resourceEntityPage} />
+    <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>
+  </EntitySwitch>
+);


### PR DESCRIPTION
## Summary
- Create custom `EntityPage.tsx` replacing the default `CatalogEntityPage`
- Component entities get: Overview, Kubernetes, K8s Resources, Crossplane tabs
- Resource entities add: Entity Scaffolder Content tab for template actions
- Tabs conditionally render based on entity annotations (e.g. `isCrossplaneAvailable`)
- Fixes `PolicyReporterPage` → `PolicyReportsPage` export rename from Kyverno plugin update

## Test plan
- [ ] CI builds new Backstage image
- [ ] Navigate to any catalog entity → tabbed layout visible
- [ ] Kubernetes tab shows for entities with K8s annotations
- [ ] Crossplane tab shows for Crossplane-managed resources
- [ ] Entity Scaffolder tab shows on Resource entities
- [ ] Policy Reporter page still works from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customized catalog entity pages with specialized layouts for different entity types (components and resources).
  * Enhanced entity page with dedicated Kubernetes and Crossplane support tabs.

* **Chores**
  * Updated policy reporter plugin integration and naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->