### PR TITLE
docs: TrueNAS crash investigation findings (KAZ-90)

### DIFF
--- a/docs/troubleshooting/truenas-crash-investigation.md
+++ b/docs/troubleshooting/truenas-crash-investigation.md
@@ -2,15 +2,17 @@
 
 **Date**: 2026-02-24
 **Status**: Open — root cause not yet confirmed
-**Impact**: Repeated TrueNAS crashes knock out iSCSI storage, causing cascading k3s cluster failures (DiskPressure, pod evictions, Flux reconciliation failures)
+**Impact**: Repeated TrueNAS crashes knock out iSCSI and NFS storage, causing pod volume mount failures and Flux reconciliation failures. Concurrent DiskPressure events on worker nodes compounded the impact.
 
 ## Environment
 
 - **TrueNAS VM**: 5 CPU cores, 20GB RAM, 30TB storage (Proxmox)
-- **k3s cluster**: Consumes iSCSI targets from TrueNAS via democratic-csi
+- **k3s cluster**: Consumes iSCSI and NFS storage from TrueNAS via democratic-csi
 - **Proxmox host**: Shared between TrueNAS VM and k3s node VMs
 
 ## Timeline (from audit logs)
+
+Audit data begins Feb 17. System was running normally from Feb 17 through Feb 19 23:50 with no boot events.
 
 | Timestamp | Event | Type |
 |-----------|-------|------|
@@ -35,9 +37,9 @@
 - **Zero ZFS events**: No pool errors, scrub issues, or degraded state
 - **1 ANOM_ABEND**: Gunicorn worker crash in Docker container (UID=apps) — not system-level
 
-### Key finding: 154 Docker containers
+### Key finding: ~154 Docker containers
 
-154 unique veth interfaces detected, indicating a large number of Docker containers running TrueNAS apps. Each boot generates heavy iptables/netfilter activity as Docker recreates networking rules.
+154 unique veth interfaces detected, suggesting approximately 154 Docker containers running TrueNAS apps (exact count may differ due to shared network namespaces or stale interfaces from crashed containers). Each boot generates heavy iptables/netfilter activity as Docker recreates networking rules.
 
 ### Pre-crash pattern
 
@@ -53,9 +55,11 @@ Events before every crash are **identical**: routine CREDENTIAL polling (~1/min 
 
 ## Hypotheses
 
-### 1. Proxmox host-level issue (most likely)
+Ranking is provisional — pending Proxmox host log analysis and TrueNAS kernel logs.
 
-The crashes leave zero trace in TrueNAS audit logs, suggesting the VM is being killed externally. Possible causes:
+### 1. Proxmox host-level issue
+
+The crashes leave zero trace in TrueNAS audit logs, suggesting the VM may be killed externally. Possible causes:
 - Proxmox OOM killer targeting the TrueNAS VM
 - Proxmox storage backend issue affecting the VM disk
 - CPU/memory overcommit on the Proxmox host
@@ -65,16 +69,16 @@ The crashes leave zero trace in TrueNAS audit logs, suggesting the VM is being k
 
 ### 2. Kernel panic from Docker container pressure
 
-154 Docker containers generate significant kernel memory pressure (network namespaces, iptables rules, cgroup allocations). A kernel panic would not appear in audit logs.
+~154 Docker containers generate significant kernel memory pressure (network namespaces, iptables rules, cgroup allocations). A kernel panic would not appear in audit logs.
 
-**Evidence for**: 154 containers is a high count for a NAS appliance. Heavy netfilter activity observed.
-**Next step**: Check `journalctl -k` on TrueNAS for panic traces. Review Docker container list and consider reducing count.
+**Evidence for**: ~154 containers is a high count for a NAS appliance. Heavy netfilter activity observed.
+**Next step**: Check `journalctl -k -b -1` on TrueNAS for panic traces from the previous boot. Review Docker container list and consider reducing count.
 
 ### 3. ZFS memory pressure
 
-ZFS ARC cache can consume large amounts of RAM. Combined with 154 Docker containers and TrueNAS middleware, 20GB may not be sufficient.
+ZFS ARC cache can consume large amounts of RAM. Combined with ~154 Docker containers and TrueNAS middleware, 20GB may not be sufficient.
 
-**Evidence for**: ZFS ARC is known to cause memory pressure. 20GB with 154 containers and ZFS is tight.
+**Evidence for**: ZFS ARC is known to cause memory pressure. 20GB with ~154 containers and ZFS is tight.
 **Next step**: Check `arc_summary` and ZFS ARC size after boot. Monitor memory usage over time.
 
 ## Required Data (not available in audit export)
@@ -90,8 +94,9 @@ To confirm root cause, we need:
 
 ## Immediate Mitigations
 
-1. **Reduce Docker containers**: Audit the 154 containers on TrueNAS. Disable non-essential apps.
+1. **Reduce Docker containers**: Audit the ~154 containers on TrueNAS. Disable non-essential apps.
 2. **Increase VM memory**: Consider bumping from 20GB to 32GB if Proxmox host allows.
-3. **Cap ZFS ARC**: Set `zfs_arc_max` to leave headroom for Docker/OS (e.g., 8GB of 20GB).
-4. **Enable Proxmox HA**: If not already enabled, configure HA for the TrueNAS VM to auto-restart on crash.
+3. **Cap ZFS ARC**: Set `zfs_arc_max` to ~40% of total RAM (e.g., 8GB of 20GB) to leave headroom for Docker containers, TrueNAS middleware, and iSCSI/NFS services. Adjust proportionally if VM memory changes.
+4. **Verify Proxmox VM auto-restart**: Ensure TrueNAS VM has `Start at boot` enabled with appropriate startup order. Consider a Proxmox-level watchdog or monitoring script to detect and restart the VM on crash.
 5. **Add monitoring**: Expose TrueNAS VM metrics to Grafana Cloud for proactive alerting.
+6. **Cross-reference cluster recovery**: See `docs/runbooks/disaster-recovery.md` for k3s cluster recovery steps following TrueNAS outages.


### PR DESCRIPTION
## Summary
- Analysed TrueNAS audit report CSV (22,401 events across 3 files, Feb 17-24)
- Found 5 boots in 7 days with only 1 intentional — crashes leave zero trace in audit logs
- Key finding: 154 Docker containers running, generating heavy iptables/netfilter load
- Documented 3 hypotheses: Proxmox host issue, kernel panic from container pressure, ZFS memory pressure
- Listed required data (journalctl, Proxmox logs, ZFS ARC stats) for root cause confirmation
- Included immediate mitigation steps

## Test plan
- [ ] Documentation review — content accuracy
- [ ] No cluster impact (docs-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new troubleshooting guide for investigating TrueNAS crashes, including environment details, audit log analysis, root cause hypotheses, required data collection procedures, and immediate mitigation strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->