### PR TITLE
fix(dev): resolve overlay bugs blocking Flux bootstrap (KAZ-105)

### DIFF
--- a/clusters/dev/infrastructure.yaml
+++ b/clusters/dev/infrastructure.yaml
@@ -44,10 +44,10 @@ spec:
   prune: true
   wait: true
   healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: caddy
-      namespace: caddy-system
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: traefik
+      namespace: traefik-system
   postBuild:
     substituteFrom:
       - kind: ConfigMap

--- a/clusters/dev/kustomization.yaml
+++ b/clusters/dev/kustomization.yaml
@@ -10,6 +10,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # Flux GitOps controllers — MUST be included or Flux prunes itself
+  - flux-system
   # Cluster variables ConfigMap — consumed by postBuild.substituteFrom
   - vars.yaml
   # Layer definitions (Flux capital-K Kustomizations)

--- a/clusters/dev/platform.yaml
+++ b/clusters/dev/platform.yaml
@@ -16,6 +16,10 @@ spec:
   wait: true
   dependsOn:
     - name: infrastructure
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization

--- a/clusters/dev/vars.yaml
+++ b/clusters/dev/vars.yaml
@@ -16,6 +16,9 @@ data:
   OP_VAULT: "Homelab"
   OP_ITEM_CLOUDFLARE: "cloudflare dns API Credentials"
   OP_ITEM_TRUENAS: "Truenas API Credential"
+  OP_ITEM_GRAFANA_CLOUD: "grafana-cloud-credentials"
+  OP_ITEM_GRAFANA_MCP_TOKEN: "grafana-mcp-token"
+  OP_ITEM_STRIPE_API_KEY: "stripe-api-key"
 
   # ── Network Configuration ──────────────────────────────────────
   METALLB_IP_RANGE: "10.3.0.200-10.3.0.210"


### PR DESCRIPTION
## Summary

- **platform.yaml**: Add `postBuild.substituteFrom` to `platform-crds` so `${OP_VAULT}` and `${OP_ITEM_GRAFANA_CLOUD}` get substituted (matches homelab pattern)
- **infrastructure.yaml**: Fix healthCheck from non-existent `Deployment/caddy` in `caddy-system` to `HelmRelease/traefik` in `traefik-system` — the dev overlay only deploys traefik
- **vars.yaml**: Add `OP_ITEM_GRAFANA_CLOUD`, `OP_ITEM_GRAFANA_MCP_TOKEN`, and `OP_ITEM_STRIPE_API_KEY` variables needed by platform and apps layers
- **kustomization.yaml**: Add `flux-system` to resources list so Flux doesn't prune itself after bootstrap

## Context

These fixes must be merged to `main` before running `flux bootstrap` on the dev cluster. Without them:
1. 1Password item names would be applied as literal `${OP_VAULT}` strings
2. The infrastructure stage would block forever waiting for a caddy Deployment that doesn't exist
3. Flux would prune its own controllers on the first reconciliation cycle

## Test plan

- [ ] Verify `kustomize build clusters/dev/` succeeds (after flux-system directory is created by bootstrap)
- [ ] Merge to main, then run `scripts/bootstrap.py` with `CLUSTER_NAME=dev`
- [ ] Confirm all Kustomizations reconcile: `flux get kustomizations --context rancher-desktop`
- [ ] Confirm all HelmReleases reconcile: `flux get helmreleases -A --context rancher-desktop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure health monitoring configuration
  * Added Flux GitOps controllers to deployment configuration
  * Enhanced platform configuration with dynamic variable substitution support

* **Configuration**
  * Added new cluster configuration variables for Grafana Cloud credentials, Grafana MCP token, and Stripe API integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->