### PR TITLE
fix(ci): fix auto-rollback for merge commits and premature cancellation

### DIFF
--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -10,7 +10,7 @@ on:
 
 concurrency:
   group: post-deploy-check
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   health-check:
@@ -78,7 +78,7 @@ jobs:
   rollback:
     name: Auto Rollback
     needs: health-check
-    if: failure()
+    if: failure() && !startsWith(github.event.head_commit.message, 'Revert "')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -93,7 +93,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git revert HEAD --no-edit
+          # Merge commits (from PR merges) require -m 1 to specify which
+          # parent to revert against. Without it, git revert fails with:
+          #   "commit XXXXX is a merge but no -m option was given"
+          PARENTS=$(git cat-file -p HEAD | grep -c '^parent')
+          if [ "$PARENTS" -gt 1 ]; then
+            git revert -m 1 HEAD --no-edit
+          else
+            git revert HEAD --no-edit
+          fi
           git push origin main
 
       - name: Create issue


### PR DESCRIPTION
## Summary
- Fix `git revert` failure on merge commits by detecting parent count and adding `-m 1`
- Change `cancel-in-progress` to `false` so health checks run to completion
- Add revert-commit guard on rollback job to prevent infinite rollback loops

## Context
PR #110 (Cilium migration) exposed all three bugs simultaneously:
1. Health check was cancelled after 15s by `cancel-in-progress: true` when a concurrent push arrived
2. Rollback triggered on the false "failure" but `git revert HEAD --no-edit` failed because HEAD was a merge commit
3. No safety net against reverting a revert commit

## Test plan
- [ ] Merge a PR that modifies `infrastructure/**` and verify health check runs to completion
- [ ] If health check fails, verify rollback creates a revert commit and GitHub issue
- [ ] Verify revert commits skip both the health check and rollback jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment rollback procedures to properly handle merge commits.
  * Improved automated post-deployment health checks to skip revert commits.
  * Optimized workflow concurrency management for improved deployment stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->