### PR TITLE
fix(ci): mask Proxmox token and update stale docs

### DIFF
--- a/.github/workflows/packer-proxmox-build.yaml
+++ b/.github/workflows/packer-proxmox-build.yaml
@@ -89,7 +89,10 @@ jobs:
 
       - name: Read Proxmox token from 1Password
         id: secrets
-        run: echo "proxmox_token=$(op read 'op://Homelab/proxmox-packer-token/credential')" >> "$GITHUB_OUTPUT"
+        run: |
+          TOKEN=$(op read 'op://Homelab/proxmox-packer-token/credential')
+          echo "::add-mask::$TOKEN"
+          echo "proxmox_token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Setup Packer
         uses: hashicorp/setup-packer@v3
@@ -132,7 +135,10 @@ jobs:
 
       - name: Read Proxmox token from 1Password
         id: secrets
-        run: echo "proxmox_token=$(op read 'op://Homelab/proxmox-packer-token/credential')" >> "$GITHUB_OUTPUT"
+        run: |
+          TOKEN=$(op read 'op://Homelab/proxmox-packer-token/credential')
+          echo "::add-mask::$TOKEN"
+          echo "proxmox_token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Setup Packer
         uses: hashicorp/setup-packer@v3
@@ -174,7 +180,10 @@ jobs:
 
       - name: Read Proxmox token from 1Password
         id: secrets
-        run: echo "proxmox_token=$(op read 'op://Homelab/proxmox-packer-token/credential')" >> "$GITHUB_OUTPUT"
+        run: |
+          TOKEN=$(op read 'op://Homelab/proxmox-packer-token/credential')
+          echo "::add-mask::$TOKEN"
+          echo "proxmox_token=$TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Setup Packer
         uses: hashicorp/setup-packer@v3

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,7 @@ diixtra-forge/
 │   ├── dns-cloudflare-sync.yaml  Cloudflare DNS record sync
 │   ├── flux-validate.yaml   Kustomize build + kubeconform on PRs
 │   ├── packer-pi-build.yaml Packer Pi image build (privileged ARC runner)
+│   ├── packer-proxmox-build.yaml Packer Proxmox template builds (ubuntu, debian, gpu)
 │   ├── post-deploy-check.yaml    Cluster health check + auto-rollback
 │   ├── renovate.yaml        Self-hosted Renovate Bot (every 6h)
 │   └── terraform-*.yaml     Plan on PR, apply on merge

--- a/docs/homelab-ops-commands.md
+++ b/docs/homelab-ops-commands.md
@@ -75,6 +75,8 @@ Quick reference for all operational commands used to manage the diixtra-forge ho
 | packer-build-gpu | `packer build -var-file="variables.auto.pkrvars.hcl" proxmox-gpu/` | packer, images |
 | packer-build-pi | `sudo packer build arm-debian/` | packer, images |
 | packer-build-pi-ci | `gh workflow run packer-pi-build.yaml` | packer, images, ci |
+| packer-build-proxmox-ci-all | `gh workflow run "Packer — Build Proxmox K8s Images" -f template=all` | packer, images, ci |
+| packer-build-proxmox-ci | `gh workflow run "Packer — Build Proxmox K8s Images" -f template={{template}}` | packer, images, ci |
 | packer-validate | `packer validate -var-file="variables.auto.pkrvars.hcl" {{template_dir}}/` | packer, images |
 | packer-token-from-1p | `export PKR_VAR_proxmox_api_token_secret=$(op read "op://Homelab/proxmox-packer-token/credential")` | packer, 1password |
 
@@ -100,7 +102,7 @@ Quick reference for all operational commands used to manage the diixtra-forge ho
 | Name | Command | Tags |
 |------|---------|------|
 | debug-traefik | `kubectl logs -n traefik-system deploy/traefik` | debug, traefik |
-| debug-metallb | `kubectl logs -n metallb-system deploy/metallb-controller` | debug, metallb |
+| debug-cilium | `kubectl -n kube-system exec ds/cilium -- cilium status --brief` | debug, cilium |
 | debug-democratic-csi-nfs | `kubectl logs -n democratic-csi deploy/truenas-nfs-democratic-csi-controller -c csi-driver` | debug, storage |
 | debug-flux-source | `kubectl logs -n flux-system deploy/source-controller` | debug, flux |
 | debug-flux-kustomize | `kubectl logs -n flux-system deploy/kustomize-controller` | debug, flux |
@@ -130,7 +132,7 @@ Quick reference for all operational commands used to manage the diixtra-forge ho
 
 ---
 
-**Total: 67 commands across 11 categories**
+**Total: 69 commands across 11 categories**
 
 ### Template Variables
 
@@ -145,6 +147,7 @@ Commands using `{{variable}}` placeholders require substitution before running:
 | `{{token}}` | 1Password Service Account token |
 | `{{issue_number}}` | Linear issue number (e.g., `75`) |
 | `{{description}}` | Short kebab-case description |
+| `{{template}}` | Packer template name (ubuntu, debian, gpu) |
 | `{{template_dir}}` | Packer template directory |
 | `{{api_key}}` | TrueNAS API key |
 | `{{title}}` | PR title |

--- a/packer/README.md
+++ b/packer/README.md
@@ -190,9 +190,39 @@ packer/
     └── pi-k8s.pkr.hcl                  # Packer template
 ```
 
-## CI/CD — Automated Pi Builds
+## CI/CD — Automated Image Builds
 
-The `arm-debian` Pi image can be built automatically via GitHub Actions:
+All image builds are automated via GitHub Actions on a **privileged ARC runner**
+(`runs-on: packer`) deployed in the `packer-runners` namespace.
+
+Infrastructure: `infrastructure/base/packer-runner/` (HelmRelease, namespace,
+1Password secret sync).
+
+### Proxmox Templates
+
+```bash
+# Trigger manually — build all templates
+gh workflow run "Packer — Build Proxmox K8s Images" -f template=all
+
+# Build a specific template
+gh workflow run "Packer — Build Proxmox K8s Images" -f template=ubuntu
+gh workflow run "Packer — Build Proxmox K8s Images" -f template=debian
+gh workflow run "Packer — Build Proxmox K8s Images" -f template=gpu
+
+# Triggers automatically on push to main when these paths change:
+#   packer/proxmox-ubuntu/**  → ubuntu only
+#   packer/proxmox-debian/**  → debian only
+#   packer/proxmox-gpu/**     → gpu only
+#   packer/scripts/provision-gpu-node.sh  → gpu only
+#   packer/scripts/provision-k8s-node.sh  → all templates
+#   packer/variables.auto.pkrvars.hcl     → all templates
+```
+
+Builds run sequentially (ubuntu → debian → gpu) to avoid Proxmox VM ID
+conflicts. The Proxmox API token is fetched at runtime from 1Password via
+`op read`.
+
+### Pi Images
 
 ```bash
 # Trigger manually
@@ -203,17 +233,8 @@ gh workflow run packer-pi-build.yaml
 #   packer/scripts/provision-k8s-node.sh
 ```
 
-The workflow runs on a **privileged ARC runner** (`runs-on: packer`) deployed in
-the `packer-runners` namespace. This runner has root access required for
-loop-device mounting, kpartx, and QEMU binfmt_misc emulation. The built image
-is compressed with `xz` and uploaded as a GitHub Actions artifact (retained 90
-days).
-
-Infrastructure: `infrastructure/base/packer-runner/` (HelmRelease, namespace,
-1Password secret sync).
-
-> Proxmox template builds (`proxmox-ubuntu`, `proxmox-debian`, `proxmox-gpu`)
-> still require manual execution from a host with Proxmox API access.
+The built Pi image is compressed with `xz` and uploaded as a GitHub Actions
+artifact (retained 90 days).
 
 ## Rebuilding Images
 


### PR DESCRIPTION
## Summary
- Adds `::add-mask::` to prevent the Proxmox API token from appearing in workflow logs (found by code review of #118)
- Updates packer README to document the new Proxmox CI workflow and removes the stale "manual execution only" callout
- Adds `packer-proxmox-build.yaml` to the architecture.md repository structure tree
- Adds Proxmox CI trigger commands to `docs/homelab-ops-commands.md`
- Replaces stale `debug-metallb` command with `debug-cilium` (MetalLB was removed in #117)

## Test plan
- [ ] Verify `::add-mask::` masks the token in workflow logs on the next Proxmox build run
- [ ] Verify docs accurately reflect the new CI capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)