### PR TITLE
fix(cilium): exclude envoy from low-memory Pi nodes (KAZ-121)

### DIFF
--- a/infrastructure/base/cilium/helm-release.yaml
+++ b/infrastructure/base/cilium/helm-release.yaml
@@ -74,7 +74,15 @@ spec:
 
     # --- Envoy proxy ---
     # Explicit limits prevent OOM on memory-constrained ARM nodes.
+    # Pi4 (2GB) excluded — tcmalloc requires 1GB contiguous mmap on startup.
     envoy:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node.kubernetes.io/low-memory
+                    operator: DoesNotExist
       resources:
         requests:
           cpu: 25m


### PR DESCRIPTION
## Summary
- Adds `envoy.affinity.nodeAffinity` to exclude nodes labelled `node.kubernetes.io/low-memory=true` from the cilium-envoy DaemonSet
- Pi4 (2GB RAM) cannot run cilium-envoy because tcmalloc requires a 1GB contiguous mmap on startup
- Pi4 retains full L3/L4 networking via the cilium agent; only L7 proxy features are lost

## Context
After adding envoy resource limits (KAZ-117, PR #125), the envoy pod on Pi4 still crashes because the 256Mi memory limit doesn't prevent tcmalloc's virtual address space allocation from failing. Pi5 (8GB) works fine with the same limits.

## Test plan
- [ ] cilium-envoy DaemonSet shows desired=4 (not 5) after merge
- [ ] No envoy pod scheduled on pi4
- [ ] Cilium HelmRelease becomes Ready
- [ ] Flux dependency chain unblocks (infrastructure-crds → infrastructure → platform-crds → platform → apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system reliability by optimizing resource allocation for networking infrastructure components on properly resourced nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->