### PR TITLE
fix(traefik): add volume-permissions initContainer for NFS ACME storage

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -70,6 +70,24 @@ spec:
     deployment:
       annotations:
         reloader.stakater.com/auto: "true" # Auto-restart when referenced Secrets/ConfigMaps change
+      # NFS does not honour fsGroup — the volume is root-owned and Traefik
+      # runs as UID 65532.  Fix permissions before the main container starts.
+      initContainers:
+        - name: volume-permissions
+          image: busybox:latest
+          command: ["sh", "-c", "chown -R 65532:65532 /data"]
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          securityContext:
+            runAsUser: 0
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
       dnsConfig:
         options:
           - name: ndots


### PR DESCRIPTION
## Summary
- NFS does not honour Kubernetes `fsGroup`, so the `/data` volume is root-owned while Traefik runs as UID 65532
- Without write access to `/data`, `acme.json` is never created and **no Let's Encrypt certificates are obtained** — all HTTPS sites show `NET::ERR_CERT_AUTHORITY_INVALID`
- Adds a busybox initContainer that `chown`s `/data` to `65532:65532` before Traefik starts
- Resource limits included for Kyverno `require-resource-limits` compliance

## Root cause
Traefik's ACME cert resolver is configured correctly (`--certificatesresolvers.letsencrypt.acme.storage=/data/acme.json`) but the NFS-backed PVC mounts as `root:root 755`. The container (UID 65532) gets `Permission denied` on write, so `acme.json` is never created.

## Related
- There is also a separate issue with the `traefik-basic-auth` 1Password item having 3 fields (`password`, `username`, `users`) — Traefik's basicAuth middleware expects exactly 1 key. This only affects the dashboard route. Needs a 1Password item update (not fixable via git).

## Test plan
- [ ] Flux reconciles the Traefik HelmRelease successfully
- [ ] initContainer runs and `/data` is owned by 65532
- [ ] `acme.json` is created in `/data`
- [ ] HTTPS sites (e.g. `nc.kazie.co.uk`) serve valid Let's Encrypt certificates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data volume permission initialization during deployment startup to ensure proper file access and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->