### PR TITLE
fix(traefik): add runAsNonRoot override to volume-permissions initContainer

### DIFF
--- a/infrastructure/base/traefik/helm-release.yaml
+++ b/infrastructure/base/traefik/helm-release.yaml
@@ -81,6 +81,7 @@ spec:
               mountPath: /data
           securityContext:
             runAsUser: 0
+            runAsNonRoot: false
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
## Summary
- The Traefik Helm chart sets `runAsNonRoot: true` at the pod level by default
- The `volume-permissions` initContainer from PR #127 needs `runAsUser: 0` to `chown` the NFS volume
- Without `runAsNonRoot: false` on the initContainer, the kubelet rejects it: `container's runAsUser breaks non-root policy`
- Adds `runAsNonRoot: false` to the initContainer's `securityContext` to override the pod-level setting

## Test plan
- [ ] Traefik pod starts successfully (initContainer completes, main container runs)
- [ ] `/data` is owned by 65532 and `acme.json` is created
- [ ] Let's Encrypt certs are obtained for IngressRoutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Traefik infrastructure configuration to adjust security context settings for the volume-permissions initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->