### PR TITLE
fix(ci): fall back to self-hosted runner when GitHub-hosted unavailable

### DIFF
--- a/.github/workflows/backstage-build.yaml
+++ b/.github/workflows/backstage-build.yaml
@@ -16,7 +16,7 @@ jobs:
   check-runner:
     name: Check GitHub Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       runner: ${{ steps.set.outputs.runner }}
     steps:
@@ -26,9 +26,17 @@ jobs:
   build:
     name: Build Backstage Image
     needs: check-runner
-    if: ${{ !cancelled() }}
+    if: ${{ needs.check-runner.result == 'success' || needs.check-runner.result == 'failure' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
     steps:
+      - name: Log runner selection
+        run: |
+          if [ "${{ needs.check-runner.result }}" != "success" ]; then
+            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
+            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/dns-cloudflare-sync.yaml
+++ b/.github/workflows/dns-cloudflare-sync.yaml
@@ -21,7 +21,7 @@ jobs:
   check-runner:
     name: Check GitHub Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       runner: ${{ steps.set.outputs.runner }}
     steps:
@@ -31,9 +31,17 @@ jobs:
   sync:
     name: Sync A Records
     needs: check-runner
-    if: ${{ !cancelled() }}
+    if: ${{ needs.check-runner.result == 'success' || needs.check-runner.result == 'failure' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
     steps:
+      - name: Log runner selection
+        run: |
+          if [ "${{ needs.check-runner.result }}" != "success" ]; then
+            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
+            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -11,7 +11,7 @@ jobs:
   check-runner:
     name: Check GitHub Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       runner: ${{ steps.set.outputs.runner }}
     steps:
@@ -21,7 +21,7 @@ jobs:
   validate:
     name: Validate Kustomize Builds
     needs: check-runner
-    if: ${{ !cancelled() }}
+    if: ${{ needs.check-runner.result == 'success' || needs.check-runner.result == 'failure' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
     strategy:
       matrix:
@@ -42,6 +42,13 @@ jobs:
           - apps/homelab
           - apps/dev
     steps:
+      - name: Log runner selection
+        run: |
+          if [ "${{ needs.check-runner.result }}" != "success" ]; then
+            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
+            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Flux CLI

--- a/.github/workflows/packer-proxmox-build.yaml
+++ b/.github/workflows/packer-proxmox-build.yaml
@@ -36,7 +36,7 @@ jobs:
   check-runner:
     name: Check GitHub Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       runner: ${{ steps.set.outputs.runner }}
     steps:
@@ -47,13 +47,21 @@ jobs:
   detect:
     name: Detect changes
     needs: check-runner
-    if: ${{ !cancelled() }}
+    if: ${{ needs.check-runner.result == 'success' || needs.check-runner.result == 'failure' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
     outputs:
       ubuntu: ${{ steps.changes.outputs.ubuntu }}
       debian: ${{ steps.changes.outputs.debian }}
       gpu: ${{ steps.changes.outputs.gpu }}
     steps:
+      - name: Log runner selection
+        run: |
+          if [ "${{ needs.check-runner.result }}" != "success" ]; then
+            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
+            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -15,7 +15,7 @@ jobs:
   check-runner:
     name: Check GitHub Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       runner: ${{ steps.set.outputs.runner }}
     steps:
@@ -24,9 +24,17 @@ jobs:
 
   renovate:
     needs: check-runner
-    if: ${{ !cancelled() }}
+    if: ${{ needs.check-runner.result == 'success' || needs.check-runner.result == 'failure' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
     steps:
+      - name: Log runner selection
+        run: |
+          if [ "${{ needs.check-runner.result }}" != "success" ]; then
+            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
+            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/terraform-cloudflare.yaml
+++ b/.github/workflows/terraform-cloudflare.yaml
@@ -22,7 +22,7 @@ jobs:
   check-runner:
     name: Check GitHub Runner
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     outputs:
       runner: ${{ steps.set.outputs.runner }}
     steps:
@@ -32,9 +32,17 @@ jobs:
   plan:
     name: Terraform Plan
     needs: check-runner
+    if: ${{ (needs.check-runner.result == 'success' || needs.check-runner.result == 'failure') && github.event_name == 'pull_request' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
-    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     steps:
+      - name: Log runner selection
+        run: |
+          if [ "${{ needs.check-runner.result }}" != "success" ]; then
+            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
+            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
+            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -80,8 +88,8 @@ jobs:
   apply:
     name: Terraform Apply
     needs: check-runner
+    if: ${{ needs.check-runner.result == 'success' && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
-    if: ${{ !cancelled() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Adds a `check-runner` probe job to all workflows that use `ubuntu-latest`
- If GitHub-hosted runners are unavailable (e.g. Actions minutes exhausted on our free plan), jobs automatically fall back to the `homelab` self-hosted runner
- Affected workflows: backstage-build, dns-cloudflare-sync, flux-validate, packer-proxmox-build, renovate, terraform-cloudflare

## How it works
1. A lightweight `check-runner` job attempts to run on `ubuntu-latest` (1-min timeout)
2. If it succeeds, it outputs `runner=ubuntu-latest`
3. Downstream jobs use `runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}`
4. If the probe fails (no runner assigned), the output is empty and `|| 'homelab'` kicks in

## Test plan
- [ ] Verify workflows trigger correctly on PR (flux-validate should run)
- [ ] Confirm `check-runner` job passes when GitHub-hosted runners are available
- [ ] Verify fallback works when minutes are exhausted (can test by temporarily using an invalid runner label)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Implemented dynamic runner selection across multiple CI workflows (Backstage build, DNS Cloudflare sync, Flux validate, Packer Proxmox, Renovate, Terraform Cloudflare).
  * Added a pre-check job and a log step to surface runner availability and document fallback to self-hosted runners.
  * Workflows now conditionally proceed based on the runner-check result while preserving existing task steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->