### PR TITLE
fix(jupyterhub): add resource limits to prePuller and hook

### DIFF
--- a/apps/base/jupyterhub/helm-release.yaml
+++ b/apps/base/jupyterhub/helm-release.yaml
@@ -81,6 +81,23 @@ spec:
             node_selector:
               node.kubernetes.io/gpu: "true"
 
+    prePuller:
+      resources:
+        requests:
+          cpu: 1m
+          memory: 8Mi
+        limits:
+          cpu: 50m
+          memory: 32Mi
+      hook:
+        resources:
+          requests:
+            cpu: 1m
+            memory: 8Mi
+          limits:
+            cpu: 50m
+            memory: 32Mi
+
     scheduling:
       userScheduler:
         enabled: false


### PR DESCRIPTION
## Summary
- Kyverno `require-resource-limits` policy blocked the JupyterHub `hook-image-puller` DaemonSet because its initContainers had no resource limits
- Adds `prePuller.resources` (DaemonSet containers/initContainers) and `prePuller.hook.resources` (hook-image-awaiter Job) with lightweight limits

## Error
```
resource DaemonSet/jupyterhub/hook-image-puller was blocked due to the following policies

require-resource-limits:
  autogen-validate-limits: 'validation error: All containers must have CPU and memory
    limits defined. rule autogen-validate-limits failed at path
    /spec/template/spec/initContainers/0/resources/limits/'
```

## Test plan
- [ ] JupyterHub HelmRelease reconciles to Ready after merge
- [ ] `hook-image-puller` DaemonSet creates successfully
- [ ] Hub pod starts and serves the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated JupyterHub configuration with resource allocation settings (CPU and memory requests/limits) for pre-pull operations, enhancing system resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->