### PR TITLE
fix(jupyterhub): correct ExternalName to match z2jh service name (KAZ-126)

### DIFF
--- a/platform/base/traefik-config/external-services.yaml
+++ b/platform/base/traefik-config/external-services.yaml
@@ -133,7 +133,7 @@ metadata:
   namespace: traefik-system
 spec:
   type: ExternalName
-  externalName: jupyterhub-proxy-public.jupyterhub.svc.cluster.local
+  externalName: proxy-public.jupyterhub.svc.cluster.local
 
 ---
 # ── Flux Operator WebUI (in-cluster, flux-system namespace) ─────


### PR DESCRIPTION
## Summary
- Fix 502 Bad Gateway on `jupyter.lab.kazie.co.uk` by correcting the ExternalName service target
- The z2jh Helm chart uses hardcoded service names (`proxy-public`) without the release name prefix — the ExternalName was incorrectly pointing to `jupyterhub-proxy-public`

## Test plan
- [ ] Verify Flux reconciles the updated ExternalName service
- [ ] Confirm `jupyter.lab.kazie.co.uk` loads the JupyterHub login page instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JupyterHub service routing configuration to ensure proper connectivity within the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->