### PR TITLE
fix(ci): use self-hosted runner directly instead of broken fallback probe

### DIFF
--- a/.github/workflows/backstage-build.yaml
+++ b/.github/workflows/backstage-build.yaml
@@ -13,30 +13,11 @@ permissions:
   packages: write
 
 jobs:
-  check-runner:
-    name: Check GitHub Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      runner: ${{ steps.set.outputs.runner }}
-    steps:
-      - id: set
-        run: echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
-
   build:
     name: Build Backstage Image
-    needs: check-runner
-    if: ${{ always() }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    runs-on: homelab
+    timeout-minutes: 30
     steps:
-      - name: Log runner selection
-        run: |
-          if [ "${{ needs.check-runner.result }}" != "success" ]; then
-            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
-            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/dns-cloudflare-sync.yaml
+++ b/.github/workflows/dns-cloudflare-sync.yaml
@@ -18,30 +18,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  check-runner:
-    name: Check GitHub Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      runner: ${{ steps.set.outputs.runner }}
-    steps:
-      - id: set
-        run: echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
-
   sync:
     name: Sync A Records
-    needs: check-runner
-    if: ${{ always() }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    runs-on: homelab
+    timeout-minutes: 10
     steps:
-      - name: Log runner selection
-        run: |
-          if [ "${{ needs.check-runner.result }}" != "success" ]; then
-            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
-            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -8,21 +8,10 @@ on:
       - "apps/**"
       - "clusters/**"
 jobs:
-  check-runner:
-    name: Check GitHub Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      runner: ${{ steps.set.outputs.runner }}
-    steps:
-      - id: set
-        run: echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
-
   validate:
     name: Validate Kustomize Builds
-    needs: check-runner
-    if: ${{ always() }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    runs-on: homelab
+    timeout-minutes: 10
     strategy:
       matrix:
         # Validate every cluster overlay independently.
@@ -42,13 +31,6 @@ jobs:
           - apps/homelab
           - apps/dev
     steps:
-      - name: Log runner selection
-        run: |
-          if [ "${{ needs.check-runner.result }}" != "success" ]; then
-            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
-            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
-          fi
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Flux CLI

--- a/.github/workflows/packer-proxmox-build.yaml
+++ b/.github/workflows/packer-proxmox-build.yaml
@@ -33,35 +33,16 @@ env:
   OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
 
 jobs:
-  check-runner:
-    name: Check GitHub Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      runner: ${{ steps.set.outputs.runner }}
-    steps:
-      - id: set
-        run: echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
-
   # ── Determine which templates need building ──────────────────────
   detect:
     name: Detect changes
-    needs: check-runner
-    if: ${{ always() }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    runs-on: homelab
+    timeout-minutes: 5
     outputs:
       ubuntu: ${{ steps.changes.outputs.ubuntu }}
       debian: ${{ steps.changes.outputs.debian }}
       gpu: ${{ steps.changes.outputs.gpu }}
     steps:
-      - name: Log runner selection
-        run: |
-          if [ "${{ needs.check-runner.result }}" != "success" ]; then
-            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
-            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,29 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-runner:
-    name: Check GitHub Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      runner: ${{ steps.set.outputs.runner }}
-    steps:
-      - id: set
-        run: echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
-
   renovate:
-    needs: check-runner
-    if: ${{ always() }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    runs-on: homelab
+    timeout-minutes: 30
     steps:
-      - name: Log runner selection
-        run: |
-          if [ "${{ needs.check-runner.result }}" != "success" ]; then
-            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
-            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
 

--- a/.github/workflows/terraform-cloudflare.yaml
+++ b/.github/workflows/terraform-cloudflare.yaml
@@ -19,30 +19,12 @@ env:
   TF_WORKING_DIR: terraform/cloudflare
 
 jobs:
-  check-runner:
-    name: Check GitHub Runner
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      runner: ${{ steps.set.outputs.runner }}
-    steps:
-      - id: set
-        run: echo "runner=ubuntu-latest" >> "$GITHUB_OUTPUT"
-
   plan:
     name: Terraform Plan
-    needs: check-runner
-    if: ${{ always() && github.event_name == 'pull_request' }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: homelab
+    timeout-minutes: 10
     steps:
-      - name: Log runner selection
-        run: |
-          if [ "${{ needs.check-runner.result }}" != "success" ]; then
-            echo "::warning::GitHub-hosted runner unavailable — falling back to self-hosted runner"
-            echo "### Runner Fallback" >> "$GITHUB_STEP_SUMMARY"
-            echo "GitHub-hosted runner probe **failed**. Running on self-hosted \`homelab\` runner." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Checkout
         uses: actions/checkout@v6
 
@@ -87,9 +69,9 @@ jobs:
 
   apply:
     name: Terraform Apply
-    needs: check-runner
-    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-    runs-on: ${{ needs.check-runner.outputs.runner || 'homelab' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    runs-on: homelab
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Removed the `check-runner` probe job from 6 workflows — when billing limits are hit, the probe queues forever on `ubuntu-latest` (timeout-minutes only applies after a runner is assigned), blocking all downstream jobs even with `always()`
- All jobs now run directly on the `homelab` self-hosted runner
- Added `timeout-minutes` to every job that was missing one so they fail cleanly if the runner is unavailable

## Workflows changed
| Workflow | Change |
|---|---|
| backstage-build | `homelab` + 30min timeout |
| dns-cloudflare-sync | `homelab` + 10min timeout |
| flux-validate | `homelab` + 10min timeout |
| packer-proxmox-build | `detect` job → `homelab` + 5min timeout |
| renovate | `homelab` + 30min timeout |
| terraform-cloudflare | `plan`/`apply` → `homelab` + 10min timeout |

> **Note:** `post-deploy-check.yaml` rollback job intentionally stays on `ubuntu-latest` — it only does git revert + GitHub API calls (no cluster access), and it's the last line of defense against bad deploys.

## Test plan
- [ ] Verify workflows appear correctly in GitHub Actions UI
- [ ] Trigger a workflow (e.g., Renovate via workflow_dispatch) and confirm it runs on the homelab runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)