### PR TITLE
fix(ci): resolve workflow parse error and missing step ID (#463)

### DIFF
--- a/.github/workflows/dns-cloudflare-sync.yaml
+++ b/.github/workflows/dns-cloudflare-sync.yaml
@@ -59,7 +59,7 @@ jobs:
                   host = m.group(1)
                   # Resolve Flux ${VAR} substitutions
                   for k, v in vars_map.items():
-                      host = host.replace(f"${{{k}}}", v)
+                      host = host.replace("${" + k + "}", v)
                   hostnames.add(host)
 
           data = {

--- a/.github/workflows/terraform-cloudflare.yaml
+++ b/.github/workflows/terraform-cloudflare.yaml
@@ -46,6 +46,7 @@ jobs:
         run: terraform init
 
       - name: Terraform Plan
+        id: plan
         working-directory: ${{ env.TF_WORKING_DIR }}
         run: terraform plan -no-color -out=tfplan
         env:


### PR DESCRIPTION
## Summary
- **dns-cloudflare-sync.yaml**: Replace Python f-string `f"${{{k}}}"` with string concatenation `"${" + k + "}"` to avoid `${{` being parsed as a GitHub Actions expression (broke the entire workflow)
- **terraform-cloudflare.yaml**: Add `id: plan` to the Terraform Plan step so `steps.plan.outputs.stdout` resolves in PR comments

Closes #463

## Test plan
- [ ] `actionlint` passes on both workflow files
- [ ] `dns-cloudflare-sync` workflow runs without "workflow file issue" error
- [ ] `terraform-cloudflare` plan output appears in PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized string handling in CloudFlare DNS sync automation.

* **Chores**
  * Enhanced GitHub Actions workflow configuration for improved access to Terraform plan outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->