### PR TITLE
fix(kyverno): bump memory limits to stop crash loop (#465)

### DIFF
--- a/platform/base/kyverno/helm-release.yaml
+++ b/platform/base/kyverno/helm-release.yaml
@@ -45,10 +45,10 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
           limits:
             cpu: 500m
-            memory: 384Mi
+            memory: 768Mi
       initContainer:
         resources:
           requests:
@@ -61,23 +61,23 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 128Mi
         limits:
           cpu: 250m
-          memory: 256Mi
+          memory: 512Mi
     cleanupController:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 128Mi
         limits:
           cpu: 250m
-          memory: 256Mi
+          memory: 512Mi
     reportsController:
       resources:
         requests:
           cpu: 50m
-          memory: 64Mi
+          memory: 128Mi
         limits:
           cpu: 250m
-          memory: 256Mi
+          memory: 512Mi


### PR DESCRIPTION
## Summary

- Kyverno admission controller was crash-looping (51 restarts in 12h) due to 384Mi memory limit
- When Kyverno webhook is down, ARC runner controller can't manage listener pods, causing GitHub Actions jobs to get stuck in `queued` state indefinitely
- Bumped admission controller memory limit to 768Mi, other controllers to 512Mi

## Changes

| Controller | Memory Limit (before) | Memory Limit (after) | Request (before) | Request (after) |
|---|---|---|---|---|
| Admission | 384Mi | 768Mi | 128Mi | 256Mi |
| Background | 256Mi | 512Mi | 64Mi | 128Mi |
| Cleanup | 256Mi | 512Mi | 64Mi | 128Mi |
| Reports | 256Mi | 512Mi | 64Mi | 128Mi |

## Test plan

- [ ] Verify Kyverno pods stabilize after merge (no more crash loops)
- [ ] Trigger a workflow run and confirm ARC runner picks it up
- [ ] Monitor Kyverno restarts over 24h

Closes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)