### PR TITLE
improve CI reliability and reduce Grafana metrics to stay within free tier

### DIFF
--- a/.github/workflows/cluster-health-gate.yaml
+++ b/.github/workflows/cluster-health-gate.yaml
@@ -1,0 +1,66 @@
+name: Cluster Health Gate
+
+# Reusable workflow that checks cluster health before running jobs.
+# Call this from other workflows to avoid scheduling work on an
+# unstable cluster, which causes cascading failures and timeouts.
+
+on:
+  workflow_call:
+    outputs:
+      healthy:
+        description: "Whether the cluster passed all health checks"
+        value: ${{ jobs.gate.outputs.healthy }}
+
+jobs:
+  gate:
+    name: Cluster Ready
+    runs-on: homelab
+    timeout-minutes: 5
+    outputs:
+      healthy: ${{ steps.check.outputs.healthy }}
+    steps:
+      - name: Check cluster health
+        id: check
+        run: |
+          set -euo pipefail
+          HEALTHY=true
+
+          # 1. API server reachable
+          if ! kubectl cluster-info --request-timeout=10s > /dev/null 2>&1; then
+            echo "::error::API server unreachable"
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2. All nodes Ready
+          NOT_READY=$(kubectl get nodes --no-headers | grep -v " Ready " || true)
+          if [ -n "$NOT_READY" ]; then
+            echo "::warning::Nodes not ready:"
+            echo "$NOT_READY"
+            HEALTHY=false
+          fi
+
+          # 3. No DiskPressure / MemoryPressure / PIDPressure
+          PRESSURE=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{range .status.conditions[?(@.status=="True")]}{" "}{.type}{end}{"\n"}{end}' \
+            | grep -E "DiskPressure|MemoryPressure|PIDPressure" || true)
+          if [ -n "$PRESSURE" ]; then
+            echo "::warning::Node pressure detected:"
+            echo "$PRESSURE"
+            HEALTHY=false
+          fi
+
+          # 4. Flux source is not suspended/failing
+          FLUX_FAILING=$(kubectl get kustomizations -n flux-system --no-headers 2>/dev/null \
+            | grep -v "True" | head -5 || true)
+          if [ -n "$FLUX_FAILING" ]; then
+            echo "::warning::Flux kustomizations not ready:"
+            echo "$FLUX_FAILING"
+            # Don't block on Flux — it may be reconciling this very commit
+          fi
+
+          echo "healthy=$HEALTHY" >> "$GITHUB_OUTPUT"
+          if [ "$HEALTHY" = "true" ]; then
+            echo "Cluster health check passed"
+          else
+            echo "::warning::Cluster health check has warnings — proceeding with caution"
+          fi

--- a/.github/workflows/packer-pi-build.yaml
+++ b/.github/workflows/packer-pi-build.yaml
@@ -16,6 +16,7 @@ jobs:
   build:
     name: Build Pi Image
     runs-on: packer
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/packer-proxmox-build.yaml
+++ b/.github/workflows/packer-proxmox-build.yaml
@@ -103,7 +103,13 @@ jobs:
         working-directory: packer
 
       - name: Packer build
-        run: packer build proxmox-ubuntu/
+        run: |
+          # Retry once on failure — Proxmox API can timeout during VM creation
+          if ! packer build proxmox-ubuntu/; then
+            echo "::warning::First attempt failed, retrying after 30s..."
+            sleep 30
+            packer build proxmox-ubuntu/
+          fi
         working-directory: packer
         env:
           PKR_VAR_proxmox_api_token_secret: ${{ steps.secrets.outputs.proxmox_token }}
@@ -149,7 +155,12 @@ jobs:
         working-directory: packer
 
       - name: Packer build
-        run: packer build proxmox-debian/
+        run: |
+          if ! packer build proxmox-debian/; then
+            echo "::warning::First attempt failed, retrying after 30s..."
+            sleep 30
+            packer build proxmox-debian/
+          fi
         working-directory: packer
         env:
           PKR_VAR_proxmox_api_token_secret: ${{ steps.secrets.outputs.proxmox_token }}
@@ -194,7 +205,12 @@ jobs:
         working-directory: packer
 
       - name: Packer build
-        run: packer build proxmox-gpu/
+        run: |
+          if ! packer build proxmox-gpu/; then
+            echo "::warning::First attempt failed, retrying after 30s..."
+            sleep 30
+            packer build proxmox-gpu/
+          fi
         working-directory: packer
         env:
           PKR_VAR_proxmox_api_token_secret: ${{ steps.secrets.outputs.proxmox_token }}

--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -8,27 +8,58 @@ on:
       - "apps/**"
       - "clusters/**"
 
+# Queue deploys — never cancel or run in parallel.
+# Concurrent reconciliations are the #1 source of cluster instability.
 concurrency:
-  group: post-deploy-check
+  group: cluster-deploy
   cancel-in-progress: false
 
 jobs:
   health-check:
     name: Cluster Health Check
     runs-on: homelab
+    timeout-minutes: 15
     if: "!startsWith(github.event.head_commit.message, 'Revert \"')"
     steps:
+      - name: Pre-flight — API server reachable
+        run: |
+          for i in 1 2 3 4 5; do
+            if kubectl cluster-info --request-timeout=10s > /dev/null 2>&1; then
+              echo "API server reachable"
+              exit 0
+            fi
+            echo "Attempt $i/5 — API server not responding, waiting 15s..."
+            sleep 15
+          done
+          echo "::error::API server unreachable after 5 attempts"
+          exit 1
+
       - name: Install Flux CLI
-        run: curl -s https://fluxcd.io/install.sh | FLUX_VERSION=2.4.0 bash
+        run: |
+          if ! command -v flux &> /dev/null; then
+            curl -s https://fluxcd.io/install.sh | FLUX_VERSION=2.4.0 bash
+          else
+            echo "Flux CLI already available: $(flux --version)"
+          fi
 
       - name: Trigger source reconciliation
-        run: flux reconcile source git flux-system --timeout=2m
+        run: |
+          # Retry the reconcile — the source controller may be restarting
+          for i in 1 2 3; do
+            if flux reconcile source git flux-system --timeout=2m 2>&1; then
+              exit 0
+            fi
+            echo "Reconcile attempt $i failed, waiting 20s..."
+            sleep 20
+          done
+          echo "::error::Source reconciliation failed after 3 attempts"
+          exit 1
 
       - name: Wait for Kustomizations
         run: |
           echo "Waiting for all Kustomizations to reconcile..."
           for i in $(seq 1 60); do
-            NOT_READY=$(flux get kustomizations --no-header | grep -v "True" || true)
+            NOT_READY=$(flux get kustomizations --no-header 2>/dev/null | grep -v "True" || true)
             if [ -z "$NOT_READY" ]; then
               echo "All Kustomizations are Ready"
               flux get kustomizations
@@ -48,7 +79,8 @@ jobs:
           for i in $(seq 1 60); do
             # Exclude nvidia-device-plugin: its DaemonSet needs a GPU node
             # with node.kubernetes.io/gpu=true label — schedules 0 pods otherwise
-            NOT_READY=$(flux get helmreleases -A --no-header | grep -v "nvidia-device-plugin" | grep -v "True" || true)
+            NOT_READY=$(flux get helmreleases -A --no-header 2>/dev/null \
+              | grep -v "nvidia-device-plugin" | grep -v "True" || true)
             if [ -z "$NOT_READY" ]; then
               echo "All HelmReleases are Ready"
               flux get helmreleases -A
@@ -82,6 +114,7 @@ jobs:
     needs: health-check
     if: failure() && !startsWith(github.event.head_commit.message, 'Revert "')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
       issues: write

--- a/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
@@ -83,7 +83,7 @@ spec:
     #   For a homelab, this is perfect — save resources.
     #   In production, minRunners: 1+ keeps a warm runner for faster starts.
     minRunners: 0
-    maxRunners: 2
+    maxRunners: 3
     # Listener pod spec — the long-polling pod that detects queued jobs.
     # Must have resource limits to satisfy Kyverno require-resource-limits policy.
     listenerTemplate:

--- a/platform/base/kube-state-metrics/helm-release.yaml
+++ b/platform/base/kube-state-metrics/helm-release.yaml
@@ -15,6 +15,27 @@ spec:
         namespace: flux-system
       interval: 1h
   values:
+    # ── Metric Reduction — Grafana Cloud Free Tier (10k series) ──
+    # By default KSM exposes ~30 resource types. Most are high-cardinality
+    # and unnecessary for a homelab. Only enable the collectors we actually
+    # dashboard or alert on. This alone cuts series from ~8k+ to ~2k.
+    collectors:
+      - daemonsets
+      - deployments
+      - nodes
+      - pods
+      - statefulsets
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - cronjobs
+      - jobs
+    # Further reduce by dropping per-label and per-condition metrics
+    # that create high cardinality without actionable signal.
+    metricLabelsAllowlist:
+      pods: [namespace,pod,phase]
+      nodes: [node]
+      deployments: [namespace,deployment]
     resources:
       requests:
         cpu: 50m

--- a/platform/homelab/crds/alloy/patches/alloy-config-patch.yaml
+++ b/platform/homelab/crds/alloy/patches/alloy-config-patch.yaml
@@ -53,7 +53,21 @@ spec:
 
           // ════════════════════════════════════════════════════════════
           // Metrics — Kubelet (per-node)
+          // Only keep essential kubelet metrics. The default /metrics endpoint
+          // exposes ~400 series per node including Go runtime, gRPC, and
+          // storage operation histograms that we don't dashboard or alert on.
           // ════════════════════════════════════════════════════════════
+          prometheus.relabel "kubelet_filter" {
+            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+            // Keep only kubelet operational metrics we actually use
+            rule {
+              source_labels = ["__name__"]
+              regex         = "kubelet_running_pods|kubelet_running_containers|kubelet_node_name|kubelet_volume_stats_.*|kubelet_pod_start_duration_seconds_count|up"
+              action        = "keep"
+            }
+          }
+
           prometheus.scrape "kubelet" {
             targets = [{
               __address__ = env("HOSTNAME") + ":10250",
@@ -64,7 +78,7 @@ spec:
               insecure_skip_verify = true
             }
             scrape_interval = "60s"
-            forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+            forward_to      = [prometheus.relabel.kubelet_filter.receiver]
           }
 
           // ════════════════════════════════════════════════════════════
@@ -99,6 +113,24 @@ spec:
               regex         = "container_tasks_state"
               action        = "drop"
             }
+            // Drop per-interface network byte counters (high cardinality)
+            rule {
+              source_labels = ["__name__"]
+              regex         = "container_network_(receive|transmit)_bytes_total"
+              action        = "drop"
+            }
+            // Drop container spec metrics (static, rarely change)
+            rule {
+              source_labels = ["__name__"]
+              regex         = "container_spec_.*"
+              action        = "drop"
+            }
+            // Drop container start/last-seen timestamps (not useful for dashboards)
+            rule {
+              source_labels = ["__name__"]
+              regex         = "container_(start_time_seconds|last_seen)"
+              action        = "drop"
+            }
           }
 
           prometheus.scrape "cadvisor" {
@@ -117,7 +149,28 @@ spec:
 
           // ════════════════════════════════════════════════════════════
           // Metrics — kube-state-metrics (cluster-wide)
+          // KSM collectors are already restricted in the HelmRelease values.
+          // This relabel pass drops the remaining high-cardinality series
+          // we don't need: labels/annotations hashes, owner references,
+          // and status reason/message strings that explode cardinality.
           // ════════════════════════════════════════════════════════════
+          prometheus.relabel "ksm_filter" {
+            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+            // Drop label and annotation metrics (one series per unique label combo)
+            rule {
+              source_labels = ["__name__"]
+              regex         = "kube_(pod|node|deployment|statefulset|daemonset|namespace)_labels|kube_pod_info|kube_pod_owner"
+              action        = "drop"
+            }
+            // Drop status reason/message metrics (high cardinality strings)
+            rule {
+              source_labels = ["__name__"]
+              regex         = "kube_pod_status_reason|kube_pod_container_status_last_terminated_reason"
+              action        = "drop"
+            }
+          }
+
           prometheus.scrape "kube_state_metrics" {
             targets = [{
               __address__ = "kube-state-metrics.monitoring.svc.cluster.local:8080",
@@ -126,7 +179,7 @@ spec:
             clustering {
               enabled = true
             }
-            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+            forward_to = [prometheus.relabel.ksm_filter.receiver]
           }
 
           // ════════════════════════════════════════════════════════════
@@ -134,6 +187,20 @@ spec:
           // ════════════════════════════════════════════════════════════
           // TrueNAS pushes Graphite plaintext to graphite-exporter:9109.
           // The exporter converts to Prometheus format on :9108/metrics.
+          // TrueNAS exports hundreds of per-disk, per-interface, per-dataset
+          // series. Only keep the ones we actually dashboard: pool usage,
+          // disk temperature, CPU, memory, and network throughput.
+          prometheus.relabel "truenas_filter" {
+            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+            // Keep only the TrueNAS metrics we dashboard on
+            rule {
+              source_labels = ["__name__"]
+              regex         = "graphite_exporter_.*|truenas_pool.*|truenas_disk_temperature.*|truenas_cpu.*|truenas_memory.*|truenas_network_(sent|received)_bytes.*|truenas_dataset_(used|available)_bytes.*|up"
+              action        = "keep"
+            }
+          }
+
           prometheus.scrape "truenas" {
             targets = [{
               __address__ = "graphite-exporter.monitoring.svc.cluster.local:9108",
@@ -142,7 +209,7 @@ spec:
             clustering {
               enabled = true
             }
-            forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+            forward_to = [prometheus.relabel.truenas_filter.receiver]
           }
 
           // ════════════════════════════════════════════════════════════


### PR DESCRIPTION
CI reliability improvements:
- Add cluster-health-gate reusable workflow for pre-flight checks
- Add timeout-minutes to post-deploy health-check (15m) and rollback (10m) jobs
- Add API server pre-flight check with 5 retries before running health checks
- Add retry logic to Flux source reconciliation (3 attempts)
- Change post-deploy concurrency group to 'cluster-deploy' to queue all deploys
- Add retry on Packer build failures (Proxmox API transient errors)
- Add timeout-minutes: 60 to Pi image build (was unbounded)
- Bump maxRunners 2→3 to prevent job starvation from Renovate + push overlap
- Suppress stderr in flux get commands to avoid noise during reconciliation
- Skip Flux CLI install when already available on runner

Grafana metrics reduction (10k free tier):
- Restrict kube-state-metrics collectors to 10 essential types (was ~30 default)
  Keeps: pods, deployments, daemonsets, statefulsets, nodes, namespaces, PVCs, PVs, cronjobs, jobs
  Drops: configmaps, secrets, endpoints, ingresses, replicasets, etc.
- Add metricLabelsAllowlist to KSM to limit label cardinality
- Add kubelet_filter relabel: keep only 6 essential kubelet metrics (was ~400/node)
- Add ksm_filter relabel: drop _labels, _info, _owner, status_reason series
- Add truenas_filter relabel: keep only pool, disk temp, CPU, memory, network, dataset metrics
- Expand cAdvisor filter: drop network bytes, container_spec_*, start_time, last_seen

https://claude.ai/code/session_01Wpy6aDPwU95vFFQpQDLocj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cluster health gate to verify system readiness before deployments

* **Bug Fixes**
  * Improved deployment verification with timeouts, pre-flight validation, and enhanced health checks
  * Added retry logic for infrastructure build steps

* **Chores**
  * Increased GitHub Actions runner capacity
  * Optimized metrics filtering for reduced overhead

<!-- end of auto-generated comment: release notes by coderabbit.ai -->