### PR TITLE
ci: switch non-cluster workflows to GitHub-hosted runners (#469)

### DIFF
--- a/.github/workflows/backstage-build.yaml
+++ b/.github/workflows/backstage-build.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build:
     name: Build Backstage Image
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/dns-cloudflare-sync.yaml
+++ b/.github/workflows/dns-cloudflare-sync.yaml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   sync:
     name: Sync A Records
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   validate:
     name: Validate Kustomize Builds
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:

--- a/.github/workflows/packer-proxmox-build.yaml
+++ b/.github/workflows/packer-proxmox-build.yaml
@@ -36,7 +36,7 @@ jobs:
   # ── Determine which templates need building ──────────────────────
   detect:
     name: Detect changes
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       ubuntu: ${{ steps.changes.outputs.ubuntu }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   renovate:
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout

--- a/.github/workflows/terraform-cloudflare.yaml
+++ b/.github/workflows/terraform-cloudflare.yaml
@@ -22,7 +22,7 @@ jobs:
   plan:
     name: Terraform Plan
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
   apply:
     name: Terraform Apply
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
-    runs-on: homelab
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Switch 6 workflows/jobs from self-hosted `homelab` to `ubuntu-latest` — they don't need cluster or Proxmox access
- Improves CI reliability and prepares for microservice repo split where public repos use free GitHub runners

**Switched to `ubuntu-latest`:**
- `backstage-build` — Docker build + GHCR push
- `flux-validate` — kustomize build + kubeconform
- `renovate` — Renovate bot
- `dns-cloudflare-sync` — file parsing + Cloudflare API
- `terraform-cloudflare` — plan + apply (both jobs)
- `packer-proxmox-build` — detect job only

**Kept on self-hosted:**
- `post-deploy-check` (health-check) — needs kubectl
- `cluster-health-gate` — needs kubectl
- `packer-*-build` (build jobs) — need Proxmox network access

Closes #469

## Test plan
- [ ] Verify `flux-validate` passes on the PR itself (it will run on `ubuntu-latest` for this PR)
- [ ] After merge, confirm `backstage-build`, `renovate`, `dns-cloudflare-sync`, and `terraform-cloudflare` trigger correctly on GitHub-hosted runners
- [ ] Confirm `post-deploy-check` and `cluster-health-gate` still run on `homelab`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to use ubuntu-latest runner environment instead of custom infrastructure across multiple deployment and validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->