### PR TITLE
fix(ci): correct 1Password vault typo in Cloudflare workflows (#471)

### DIFF
--- a/.github/workflows/dns-cloudflare-sync.yaml
+++ b/.github/workflows/dns-cloudflare-sync.yaml
@@ -32,7 +32,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CF_API_TOKEN: op://Homela/cloudflare dns API Credentials/credential
+          CF_API_TOKEN: op://Homelab/cloudflare dns API Credentials/credential
 
       - name: Extract hostnames from IngressRoutes
         id: extract

--- a/.github/workflows/terraform-cloudflare.yaml
+++ b/.github/workflows/terraform-cloudflare.yaml
@@ -36,7 +36,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CLOUDFLARE_API_TOKEN: op://Homela/cloudflare dns API Credentials/credential
+          CLOUDFLARE_API_TOKEN: op://Homelab/cloudflare dns API Credentials/credential
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
@@ -83,7 +83,7 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CLOUDFLARE_API_TOKEN: op://Homela/cloudflare dns API Credentials/credential
+          CLOUDFLARE_API_TOKEN: op://Homelab/cloudflare dns API Credentials/credential
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4


### PR DESCRIPTION
## Summary
- Fix truncated 1Password vault name `op://Homela/...` → `op://Homelab/...` in two workflows
- This was causing the 1Password load-secrets action to fail when resolving Cloudflare API credentials

**Affected workflows:**
- `dns-cloudflare-sync.yaml` (1 occurrence)
- `terraform-cloudflare.yaml` (2 occurrences — plan + apply jobs)

Closes #471

## Test plan
- [ ] After merge, trigger `dns-cloudflare-sync` via workflow_dispatch and confirm it resolves the Cloudflare token
- [ ] Open a test PR touching `terraform/cloudflare/` to confirm the plan job loads the secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret reference paths in CI/CD workflows to ensure proper credential retrieval during automated deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->