### PR TITLE
fix(ci): pin fluxcd/flux2/action to v2.8.1 (#472)

### DIFF
--- a/.github/workflows/flux-validate.yaml
+++ b/.github/workflows/flux-validate.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Flux CLI
-        uses: fluxcd/flux2/action@main
+        uses: fluxcd/flux2/action@v2.8.1
       - name: Validate Kustomize build
         # 'kustomize build' renders the final YAML without applying it.
         # If this fails, the manifests have structural issues.


### PR DESCRIPTION
## Summary
- Pin `fluxcd/flux2/action` from `@main` (floating) to `@v2.8.1` (latest release)
- Prevents non-deterministic builds on ephemeral GitHub-hosted runners
- Renovate will keep this updated automatically via the `github-actions` manager + automerge

Closes #472

## Test plan
- [ ] Verify `flux-validate` passes on this PR (it uses the pinned action to validate manifests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to use a stable version instead of the development branch for improved reliability. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->