### PR TITLE
fix(jupyterhub): increase KubeSpawner API timeout for PVC creation

### DIFF
--- a/apps/base/jupyterhub/helm-release.yaml
+++ b/apps/base/jupyterhub/helm-release.yaml
@@ -28,6 +28,14 @@ spec:
     timeout: 10m
   values:
     hub:
+      config:
+        KubeSpawner:
+          # Default is 3s — too short when the hub event loop is slow
+          # (e.g. SQLite over NFS on an overloaded Pi node). API calls
+          # time out before the event loop can send them, causing
+          # "Could not create PVC" spawn failures.
+          k8s_api_request_timeout: 30
+          k8s_api_request_retry_timeout: 60
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
## Summary

- Increase `k8s_api_request_timeout` from 3s to 30s and `k8s_api_request_retry_timeout` from 30s to 60s to fix "Could not create PVC claim-jameskazie" spawn failures
- Root cause: hub on pi5 has event loop blocked 7-17s (SQLite over NFS + 268% CPU overcommit), causing every 3s API call to time out

## Test plan

- [ ] Flux reconciles the HelmRelease successfully
- [ ] Spawn a notebook at jupyter.lab.kazie.co.uk — PVC `claim-jameskazie` is created and pod starts
- [ ] Check hub logs: no more repeated "Attempting to create pvc" timeout retries

Follow-up: #580 (switch hub DB from NFS to iSCSI to fix the underlying event loop latency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)