### PR TITLE
fix: switch JupyterHub hub DB from NFS to iSCSI storage (#580)

### DIFF
--- a/apps/base/jupyterhub/helm-release.yaml
+++ b/apps/base/jupyterhub/helm-release.yaml
@@ -30,10 +30,9 @@ spec:
     hub:
       config:
         KubeSpawner:
-          # Default is 3s — too short when the hub event loop is slow
-          # (e.g. SQLite over NFS on an overloaded Pi node). API calls
-          # time out before the event loop can send them, causing
-          # "Could not create PVC" spawn failures.
+          # Default is 3s — too short on a resource-constrained Pi node.
+          # API calls can time out before the event loop processes them,
+          # causing "Could not create PVC" spawn failures.
           k8s_api_request_timeout: 30
           k8s_api_request_retry_timeout: 60
       resources:
@@ -45,7 +44,7 @@ spec:
           memory: 512Mi
       db:
         pvc:
-          storageClassName: truenas-nfs
+          storageClassName: truenas-iscsi
 
     proxy:
       service:


### PR DESCRIPTION
SQLite over NFS causes event loop blocking (7-17s) due to poor file-locking support, leading to proxy failures and spawn timeouts. iSCSI block storage provides correct locking semantics and lower latency for random I/O.