### PR TITLE
feat(netpol): redeploy CiliumNetworkPolicy for low-risk namespaces in audit mode

### DIFF
--- a/clusters/homelab/platform.yaml
+++ b/clusters/homelab/platform.yaml
@@ -55,3 +55,7 @@ spec:
   wait: true
   dependsOn:
     - name: platform-crds
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-vars

--- a/infrastructure/base/cilium/helm-release.yaml
+++ b/infrastructure/base/cilium/helm-release.yaml
@@ -130,3 +130,9 @@ spec:
         limits:
           cpu: 250m
           memory: 256Mi
+
+    # --- Network Policy Audit Mode ---
+    # Log policy violations without dropping traffic. All CiliumNetworkPolicy
+    # resources are observed-only until this is removed or set to false.
+    # Monitor via Hubble UI at cilium.lab.kazie.co.uk before enforcing.
+    policyAuditMode: true

--- a/platform/base/network-policies/backstage.yaml
+++ b/platform/base/network-policies/backstage.yaml
@@ -1,0 +1,92 @@
+# ══════════════════════════════════════════════════════════════════
+# backstage — Developer Portal
+#
+# Backstage is the internal developer portal. It receives ingress
+# traffic from Traefik, talks to its own PostgreSQL database, the
+# Kubernetes API (for catalog discovery), and GitHub (for the
+# GitHub App integration).
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: backstage-default-deny
+  namespace: backstage
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: backstage-allow-ingress-traefik
+  namespace: backstage
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: traefik-system
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: backstage-allow-egress-kube-api
+  namespace: backstage
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: backstage-allow-egress-github
+  namespace: backstage
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: api.github.com
+        - matchPattern: "*.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: backstage-allow-egress-postgresql
+  namespace: backstage
+spec:
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: backstage
+            app.kubernetes.io/name: postgresql
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+# Allow Backstage to reach Policy Reporter REST API
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: backstage-allow-egress-policy-reporter
+  namespace: backstage
+spec:
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: policy-reporter
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP

--- a/platform/base/network-policies/cluster-wide.yaml
+++ b/platform/base/network-policies/cluster-wide.yaml
@@ -1,0 +1,26 @@
+# ══════════════════════════════════════════════════════════════════
+# Cluster-wide Network Policies
+#
+# Universal exceptions that apply to all pods in the cluster.
+# Currently: allow DNS resolution via CoreDNS in kube-system.
+# Without this, default-deny egress policies would break DNS for
+# every namespace.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: allow-dns
+spec:
+  endpointSelector: {}
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP

--- a/platform/base/network-policies/kustomization.yaml
+++ b/platform/base/network-policies/kustomization.yaml
@@ -1,0 +1,22 @@
+# ══════════════════════════════════════════════════════════════════
+# CiliumNetworkPolicy — Phased Rollout (ADR-008 Phase 3)
+# ══════════════════════════════════════════════════════════════════
+# Restored from commit c6aa00a^ with minimal modifications.
+# policyAuditMode is enabled globally in the Cilium HelmRelease —
+# these policies log violations without dropping traffic until
+# audit mode is explicitly removed.
+#
+# Phase 1: low-risk namespaces (monitoring, backstage, reloader,
+#   policy-reporter) + cluster-wide DNS allow.
+# Phase 2: core infra (democratic-csi, arc-*, packer-runners, nvidia).
+# Phase 3: critical services (traefik, flux, onepassword, kyverno,
+#   crossplane).
+# ══════════════════════════════════════════════════════════════════
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-wide.yaml
+  - monitoring.yaml
+  - backstage.yaml
+  - reloader.yaml
+  - policy-reporter.yaml

--- a/platform/base/network-policies/monitoring.yaml
+++ b/platform/base/network-policies/monitoring.yaml
@@ -1,0 +1,88 @@
+# ══════════════════════════════════════════════════════════════════
+# monitoring — Observability Stack
+#
+# The monitoring namespace runs Grafana Alloy (metrics/logs agent),
+# kube-state-metrics, and graphite-exporter. Alloy scrapes metrics
+# from pods across all namespaces and ships them to Grafana Cloud.
+# It needs broad cluster egress for scraping and HTTPS egress to
+# Grafana Cloud endpoints.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monitoring-default-deny
+  namespace: monitoring
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monitoring-allow-egress-cluster
+  namespace: monitoring
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - cluster
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monitoring-allow-egress-grafana-cloud
+  namespace: monitoring
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchPattern: "*.grafana.net"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# Allow TrueNAS to push graphite metrics to graphite-exporter (LoadBalancer)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monitoring-allow-ingress-truenas-graphite
+  namespace: monitoring
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: graphite-exporter
+  ingress:
+    - fromCIDR:
+        - ${TRUENAS_HOST}/32
+      toPorts:
+        - ports:
+            - port: "9109"
+              protocol: TCP
+---
+# Allow cluster-internal ingress to monitoring pods (metrics endpoints
+# for kube-state-metrics, Alloy, graphite-exporter)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monitoring-allow-ingress-cluster-scrape
+  namespace: monitoring
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEntities:
+        - cluster
+---
+# kube-state-metrics needs direct API server access to watch cluster resources
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: monitoring-allow-egress-kube-api
+  namespace: monitoring
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/base/network-policies/policy-reporter.yaml
+++ b/platform/base/network-policies/policy-reporter.yaml
@@ -1,0 +1,46 @@
+# ══════════════════════════════════════════════════════════════════
+# policy-reporter — Policy Report Aggregator
+#
+# Policy Reporter aggregates Kyverno PolicyReport CRDs and exposes
+# them via a REST API. Backstage queries this API to display policy
+# compliance data. Policy Reporter needs egress to the Kubernetes
+# API to watch PolicyReport resources, and ingress from the
+# backstage namespace for API queries.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter-default-deny
+  namespace: policy-reporter
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter-allow-ingress-backstage
+  namespace: policy-reporter
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: backstage
+      toPorts:
+        - ports:
+            - port: "8080"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: policy-reporter-allow-egress-kube-api
+  namespace: policy-reporter
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/base/network-policies/reloader.yaml
+++ b/platform/base/network-policies/reloader.yaml
@@ -1,0 +1,29 @@
+# ══════════════════════════════════════════════════════════════════
+# reloader — ConfigMap/Secret Change Watcher
+#
+# Reloader watches for changes to ConfigMaps and Secrets and
+# triggers rolling restarts of dependent workloads. It only needs
+# egress to the Kubernetes API to watch resources and patch
+# Deployments/StatefulSets/DaemonSets.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: reloader-default-deny
+  namespace: reloader
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: reloader-allow-egress-kube-api
+  namespace: reloader
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/homelab/policies/kustomization.yaml
+++ b/platform/homelab/policies/kustomization.yaml
@@ -5,3 +5,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/kyverno-policies
+  - ../../base/network-policies


### PR DESCRIPTION
## Summary

Restores the Phase 1 (low-risk) CiliumNetworkPolicy resources reverted in `c6aa00a`, deployed in **audit-only mode** so traffic flows can be validated via Hubble before enforcement.

- Enable `policyAuditMode: true` in Cilium HelmRelease — policies log violations without dropping traffic
- Restore `postBuild.substituteFrom` on the `platform` Kustomization (needed for `${TRUENAS_HOST}` substitution)
- Deploy default-deny + fine-grained allowlist policies for: **monitoring, backstage, reloader, policy-reporter**
- Deploy cluster-wide DNS allow (`CiliumClusterwideNetworkPolicy`)

### Phased rollout plan (ADR-008 Phase 3)

| PR | Namespaces | Status |
|----|-----------|--------|
| **This PR** | monitoring, backstage, reloader, policy-reporter | Phase 1 |
| PR 2 | democratic-csi, arc-runners, arc-system, packer-runners, nvidia-device-plugin | Planned |
| PR 3 | traefik-system, flux-system, onepassword-system, kyverno-system, crossplane-system | Planned |
| PR 4 | Remove `policyAuditMode` (enforce) | After Hubble validation |

## Test plan

- [ ] Flux reconciles all Kustomizations successfully after merge
- [ ] `kubectl get ciliumnetworkpolicy -A` shows 17 policies + 1 clusterwide policy
- [ ] `kubectl get ciliumnetworkpolicy -n monitoring monitoring-allow-ingress-truenas-graphite -o yaml` confirms `${TRUENAS_HOST}` substituted to `10.2.0.232`
- [ ] Hubble UI (`cilium.lab.kazie.co.uk`) shows `AUDIT` verdicts, no `DROPPED` verdicts
- [ ] All workloads in affected namespaces remain healthy
- [ ] Post-deploy health check workflow passes

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)