### PR TITLE
feat(netpol): add CiliumNetworkPolicy for core infra namespaces

### DIFF
--- a/platform/base/network-policies/arc-runners.yaml
+++ b/platform/base/network-policies/arc-runners.yaml
@@ -1,0 +1,48 @@
+# ══════════════════════════════════════════════════════════════════
+# arc-runners — GitHub Actions Runner Controller
+#
+# HIGH RISK — These pods execute arbitrary CI/CD workflows from
+# GitHub Actions. Network access is locked down tightly to only
+# what is needed: GitHub/GHCR for workflow communication and image
+# pulls, and the Kubernetes API for Flux status checks.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-runners-default-deny
+  namespace: arc-runners
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-runners-allow-egress-github
+  namespace: arc-runners
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: api.github.com
+        - matchPattern: "*.githubusercontent.com"
+        - matchName: ghcr.io
+        - matchPattern: "*.ghcr.io"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-runners-allow-egress-kube-api
+  namespace: arc-runners
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/base/network-policies/arc-system.yaml
+++ b/platform/base/network-policies/arc-system.yaml
@@ -1,0 +1,46 @@
+# ══════════════════════════════════════════════════════════════════
+# arc-system — Actions Runner Controller
+#
+# The ARC controller manages GitHub Actions runner scale sets.
+# It watches the Kubernetes API for AutoScalingRunnerSet CRDs and
+# communicates with GitHub APIs to register/deregister runners.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-system-default-deny
+  namespace: arc-system
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+# ARC controller needs GitHub API access to manage runner registrations
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-system-allow-egress-github
+  namespace: arc-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: api.github.com
+        - matchPattern: "*.actions.githubusercontent.com"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: arc-system-allow-egress-kube-api
+  namespace: arc-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/base/network-policies/democratic-csi.yaml
+++ b/platform/base/network-policies/democratic-csi.yaml
@@ -1,0 +1,49 @@
+# ══════════════════════════════════════════════════════════════════
+# democratic-csi — Storage Provisioner
+#
+# democratic-csi provisions iSCSI and NFS volumes from TrueNAS.
+# The CSI controller watches PVC/PV objects via the Kubernetes API
+# and calls the TrueNAS API (HTTPS port 443) to create/delete
+# datasets and targets. iSCSI data path uses port 3260, NFS uses
+# port 2049.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: democratic-csi-default-deny
+  namespace: democratic-csi
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: democratic-csi-allow-egress-truenas
+  namespace: democratic-csi
+spec:
+  endpointSelector: {}
+  egress:
+    - toCIDR:
+        - ${TRUENAS_HOST}/32
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+            - port: "3260"
+              protocol: TCP
+            - port: "2049"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: democratic-csi-allow-egress-kube-api
+  namespace: democratic-csi
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/base/network-policies/kustomization.yaml
+++ b/platform/base/network-policies/kustomization.yaml
@@ -20,3 +20,8 @@ resources:
   - backstage.yaml
   - reloader.yaml
   - policy-reporter.yaml
+  - democratic-csi.yaml
+  - arc-runners.yaml
+  - arc-system.yaml
+  - packer-runners.yaml
+  - nvidia-device-plugin.yaml

--- a/platform/base/network-policies/nvidia-device-plugin.yaml
+++ b/platform/base/network-policies/nvidia-device-plugin.yaml
@@ -1,0 +1,29 @@
+# ══════════════════════════════════════════════════════════════════
+# nvidia-device-plugin — NVIDIA GPU Device Plugin
+#
+# The device plugin DaemonSet only schedules on nodes labelled
+# node.kubernetes.io/gpu=true. It communicates with kubelet via
+# Unix socket (host-local, no network) and needs API server access
+# to register Extended Resources. No internet egress required.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nvidia-device-plugin-default-deny
+  namespace: nvidia-device-plugin
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: nvidia-device-plugin-allow-egress-kube-api
+  namespace: nvidia-device-plugin
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver

--- a/platform/base/network-policies/packer-runners.yaml
+++ b/platform/base/network-policies/packer-runners.yaml
@@ -1,0 +1,47 @@
+# ══════════════════════════════════════════════════════════════════
+# packer-runners — Packer Build Runners
+#
+# HIGH RISK — These pods run Packer builds which may download ISOs
+# and execute arbitrary build scripts. Network access is restricted
+# to GitHub for workflow communication and the Kubernetes API.
+# ══════════════════════════════════════════════════════════════════
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: packer-runners-default-deny
+  namespace: packer-runners
+spec:
+  endpointSelector: {}
+  ingress: []
+  egress: []
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: packer-runners-allow-egress-github
+  namespace: packer-runners
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchName: github.com
+        - matchName: api.github.com
+        - matchPattern: "*.githubusercontent.com"
+        - matchName: ghcr.io
+        - matchPattern: "*.ghcr.io"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: packer-runners-allow-egress-kube-api
+  namespace: packer-runners
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - kube-apiserver


### PR DESCRIPTION
## Summary

Phase 2 of the CiliumNetworkPolicy rollout (ADR-008). Adds default-deny + fine-grained allowlist policies for core infrastructure namespaces, under audit mode (`policyAuditMode: true` from PR #621).

- **democratic-csi**: egress to TrueNAS API (port 443) and iSCSI (port 3260) via `${TRUENAS_HOST}`
- **arc-runners**: egress to GitHub/GHCR only (high-risk namespace, locked down)
- **arc-system**: egress to GitHub API for runner registration
- **packer-runners**: egress to GitHub/GHCR only (high-risk namespace, locked down)
- **nvidia-device-plugin**: egress to kube-apiserver only (new namespace, not in original policies)

### Rollout progress

| PR | Namespaces | Status |
|----|-----------|--------|
| #621 | monitoring, backstage, reloader, policy-reporter | Merged |
| **This PR** | democratic-csi, arc-runners, arc-system, packer-runners, nvidia-device-plugin | Phase 2 |
| PR 3 | traefik-system, flux-system, onepassword-system, kyverno-system, crossplane-system | Planned |
| PR 4 | Remove `policyAuditMode` (enforce) | After Hubble validation |

## Test plan

- [ ] Flux reconciles all Kustomizations successfully
- [ ] `kubectl get ciliumnetworkpolicy -A` shows 31 namespace policies + 1 clusterwide
- [ ] `kubectl get cnp -n democratic-csi democratic-csi-allow-egress-truenas -o yaml` confirms `${TRUENAS_HOST}` substituted to `10.2.0.232`
- [ ] Hubble UI shows `AUDIT` verdicts for new namespaces, no `DROPPED`
- [ ] GitHub Actions workflows still execute on arc-runners
- [ ] PVC provisioning still works (democratic-csi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added network security policies across multiple system namespaces (Arc runners, Arc system, Democratic CSI, NVIDIA device plugin, Packer runners) with default-deny posture and selective allowances for GitHub services, container registries, Kubernetes API, and storage endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->