### PR TITLE
feat: deploy Falco + Falcosidekick for runtime security monitoring (#461)

### DIFF
--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -88,6 +88,10 @@ spec:
       kind: HelmRelease
       name: arc-runner-set-packer
       namespace: packer-runners
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: falco
+      namespace: falco-system
     # nvidia-device-plugin intentionally excluded from healthChecks.
     # The DaemonSet has a nodeSelector (node.kubernetes.io/gpu=true) so it
     # schedules 0 pods until the GPU node joins. Including it here would

--- a/infrastructure/base/falco/helm-release.yaml
+++ b/infrastructure/base/falco/helm-release.yaml
@@ -1,0 +1,86 @@
+# Falco — eBPF-based runtime security monitoring
+#
+# Deploys Falco as a DaemonSet on every node to detect anomalous
+# container behaviour (shell spawns, sensitive file reads, privilege
+# escalation, etc.) using the modern eBPF driver.
+#
+# Falcosidekick forwards events directly to Grafana Cloud Loki
+# for centralised alerting and dashboarding.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: falco
+  namespace: falco-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: falco
+      version: "*"          # Lab: always use latest. Pin in production.
+      sourceRef:
+        kind: HelmRepository
+        name: falcosecurity
+        namespace: flux-system
+      interval: 1h
+  install:
+    timeout: 10m
+  upgrade:
+    timeout: 10m
+
+  # Inject Grafana Cloud API key from the 1Password-synced secret
+  # into Falcosidekick's Loki config. The key never appears in Git.
+  # optional: true lets Falco deploy before the Secret exists —
+  # runtime detection works immediately, Loki forwarding starts
+  # once the 1Password operator syncs the credential.
+  valuesFrom:
+    - kind: Secret
+      name: grafana-cloud-credentials
+      valuesKey: credential
+      targetPath: falcosidekick.config.loki.apikey
+      optional: true
+
+  values:
+    # ── Falco Driver ──────────────────────────────────────────────
+    driver:
+      kind: modern_ebpf
+
+    # ── Falco Engine ──────────────────────────────────────────────
+    # The default rules ship curated detections mapped to MITRE
+    # ATT&CK tactics. json_output and http_output are auto-configured
+    # by the chart when falcosidekick.enabled=true.
+    falco:
+      grpc:
+        enabled: false
+      grpc_output:
+        enabled: false
+
+    # ── Falco Resources ──────────────────────────────────────────
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+
+    # ── Falcosidekick ─────────────────────────────────────────────
+    # Forwards Falco events to Grafana Cloud Loki for centralised
+    # log aggregation, alerting, and dashboard integration.
+    falcosidekick:
+      enabled: true
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 200m
+          memory: 128Mi
+      config:
+        loki:
+          # URL and username are Flux-substituted from cluster-vars.
+          # API key is injected via valuesFrom above.
+          hostport: "${GRAFANA_LOKI_URL}"
+          user: "${GRAFANA_LOKI_USERNAME}"
+          # Tenant header required by Grafana Cloud multi-tenant Loki
+          tenant: "${GRAFANA_LOKI_USERNAME}"

--- a/infrastructure/base/falco/kustomization.yaml
+++ b/infrastructure/base/falco/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-release.yaml
+  - onepassword-item.yaml

--- a/infrastructure/base/falco/namespace.yaml
+++ b/infrastructure/base/falco/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: falco-system
+  labels:
+    app.kubernetes.io/part-of: falco
+    app.kubernetes.io/managed-by: flux
+    # Falco needs privileged access for eBPF-based syscall monitoring.
+    # This label disables namespace-scoped PSA enforcement.
+    pod-security.kubernetes.io/enforce: privileged

--- a/infrastructure/base/falco/onepassword-item.yaml
+++ b/infrastructure/base/falco/onepassword-item.yaml
@@ -1,0 +1,12 @@
+# Same Grafana Cloud credential as monitoring/grafana-cloud-credentials,
+# synced separately because 1Password secrets are namespace-scoped.
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: grafana-cloud-credentials
+  namespace: falco-system
+  labels:
+    app.kubernetes.io/part-of: falco
+    app.kubernetes.io/managed-by: flux
+spec:
+  itemPath: "vaults/${OP_VAULT}/items/${OP_ITEM_GRAFANA_CLOUD}"

--- a/infrastructure/base/flux-addons/helm-repositories.yaml
+++ b/infrastructure/base/flux-addons/helm-repositories.yaml
@@ -169,6 +169,16 @@ spec:
   interval: 24h
   url: https://hub.jupyter.org/helm-chart/
 ---
+# Falco — runtime security monitoring (eBPF-based threat detection)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: falcosecurity
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://falcosecurity.github.io/charts
+---
 # Flux Operator — lifecycle manager and web UI for Flux CD
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/infrastructure/homelab/kustomization.yaml
+++ b/infrastructure/homelab/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../base/packer-runner
   - ../base/nvidia-device-plugin
   - ../base/flux-operator
+  - ../base/falco
   # Cilium L2 announcements — need Cilium CRDs from infrastructure-crds
   - cilium/l2-config.yaml
 patches:

--- a/platform/base/kyverno-policies/pod-security-baseline.yaml
+++ b/platform/base/kyverno-policies/pod-security-baseline.yaml
@@ -32,6 +32,7 @@ spec:
                 - monitoring
                 - packer-runners
                 - nvidia-device-plugin
+                - falco-system
       validate:
         failureAction: Enforce
         podSecurity:

--- a/platform/base/kyverno-policies/pod-security-restricted.yaml
+++ b/platform/base/kyverno-policies/pod-security-restricted.yaml
@@ -29,6 +29,7 @@ spec:
                 - kyverno-system
                 - democratic-csi
                 - monitoring
+                - falco-system
       validate:
         failureAction: Audit
         podSecurity:


### PR DESCRIPTION
## Summary
- Deploy Falco as a DaemonSet on all nodes with the modern eBPF driver for runtime threat detection
- Enable Falcosidekick to forward events directly to Grafana Cloud Loki using existing 1Password-managed credentials
- Add `falcosecurity` HelmRepository to flux-addons
- Create `falco-system` namespace with privileged PSA enforcement label
- Exclude `falco-system` from Kyverno pod-security-baseline (Enforce) and pod-security-restricted (Audit) policies
- Add Falco HelmRelease to infrastructure health checks
- Use `optional: true` on `valuesFrom` to prevent bootstrap cascade-blocking

Closes #461

## Test plan
- [ ] Verify Falco DaemonSet pods are running on all nodes (`kubectl get pods -n falco-system`)
- [ ] Verify Falcosidekick deployment is running (`kubectl get deploy -n falco-system`)
- [ ] Confirm Falco events appear in Grafana Cloud Loki
- [ ] Verify Flux reconciliation completes without errors (`flux get helmreleases -A`)
- [ ] Confirm infrastructure health check passes with Falco included

🤖 Generated with [Claude Code](https://claude.com/claude-code)