### PR TITLE
fix(arc): add RBAC for health check runners

### DIFF
--- a/infrastructure/base/github-actions-runner/rbac-flux-reader.yaml
+++ b/infrastructure/base/github-actions-runner/rbac-flux-reader.yaml
@@ -20,8 +20,11 @@ rules:
     resources: ["gitrepositories"]
     verbs: ["get", "list", "patch"]
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "nodes"]
     verbs: ["get", "list"]
+  # kubectl cluster-info needs access to /api and /version
+  - nonResourceURLs: ["/api", "/api/*", "/version"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Summary
- Adds `nodes` (get/list) to the `flux-reader` ClusterRole so health check workflows can run `kubectl get nodes` and check node conditions
- Adds `nonResourceURLs` (`/api`, `/api/*`, `/version`) so `kubectl cluster-info` works from runner pods

## Context
The post-deploy health check and cluster-health-gate workflows run on self-hosted ARC runners using the `arc-runner-flux-reader` service account. The `flux-reader` ClusterRole was missing permissions for `kubectl cluster-info` and `kubectl get nodes`, causing the pre-flight check to fail with "API server unreachable after 5 attempts".

## Test plan
- [ ] Merge and wait for Flux to reconcile the ClusterRole
- [ ] Trigger a push to main and verify the post-deploy health check passes the pre-flight step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

- Expanded GitHub Actions runner's access permissions to include cluster node information and resources in addition to existing pod-level access, enabling broader visibility into cluster infrastructure.
- Added permissions allowing the runner to access cluster API endpoints and version information, supporting enhanced cluster diagnostics, status monitoring, and operational awareness capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->