### PR TITLE
fix(falco): use block-scalar YAML document to preserve Loki username string type (#627)

### DIFF
--- a/infrastructure/base/falco/helm-release.yaml
+++ b/infrastructure/base/falco/helm-release.yaml
@@ -38,20 +38,15 @@ spec:
       valuesKey: credential
       targetPath: falcosidekick.config.loki.apikey
       optional: true
-    # Loki username/tenant injected from the same 1Password-synced Secret.
-    # Flux postBuild substitution + YAML/JSON round-trip coerces numeric
-    # strings to numbers, breaking Helm's b64enc. Secrets are immune
-    # because the 1Password operator writes directly to Kubernetes.
+    # Loki username/tenant injected from a ConfigMap whose values.yaml
+    # key contains a YAML document inside a block scalar. This bypasses
+    # both Flux's YAML/JSON round-trip (which coerces bare numeric
+    # strings to numbers) and Helm's strvals parser (used by targetPath,
+    # which also coerces). The block scalar preserves quoted strings.
     # See https://github.com/fluxcd/kustomize-controller/issues/554
-    - kind: Secret
-      name: grafana-cloud-credentials
-      valuesKey: username
-      targetPath: falcosidekick.config.loki.user
-      optional: true
-    - kind: Secret
-      name: grafana-cloud-credentials
-      valuesKey: username
-      targetPath: falcosidekick.config.loki.tenant
+    - kind: ConfigMap
+      name: falco-loki-values
+      valuesKey: values.yaml
       optional: true
 
   values:

--- a/infrastructure/base/falco/kustomization.yaml
+++ b/infrastructure/base/falco/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - loki-values.yaml
   - helm-release.yaml
   - onepassword-item.yaml

--- a/infrastructure/base/falco/loki-values.yaml
+++ b/infrastructure/base/falco/loki-values.yaml
@@ -1,0 +1,19 @@
+# Falcosidekick Loki values as a YAML document inside a block scalar.
+# Flux's YAML/JSON round-trip coerces bare numeric strings to numbers,
+# and Helm's strvals (used by valuesFrom targetPath) does the same.
+# Wrapping the values in a block scalar preserves the YAML content as a
+# string through Flux's pipeline. The helm-controller then parses the
+# content as YAML, where the double-quoted "..." values stay strings.
+# See https://github.com/fluxcd/kustomize-controller/issues/554
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: falco-loki-values
+  namespace: falco-system
+data:
+  values.yaml: |
+    falcosidekick:
+      config:
+        loki:
+          user: "${GRAFANA_LOKI_USERNAME}"
+          tenant: "${GRAFANA_LOKI_USERNAME}"


### PR DESCRIPTION
## Summary

Third attempt at fixing the Falco b64enc error. Both previous approaches failed:

1. **ConfigMap with bare value** (PR #628): Flux's YAML/JSON round-trip coerces `data.GRAFANA_LOKI_USERNAME: "1481965"` to a number, causing server-side dry-run rejection
2. **1Password Secret with `targetPath`** (PR #629): Helm's `strvals` parser (used by `valuesFrom` `targetPath`) also coerces numeric strings to numbers

**This fix**: Embed the Loki user/tenant values inside a YAML document stored as a **block scalar** (`|`) in a ConfigMap. The block scalar preserves the content as a string through Flux's pipeline. The helm-controller then parses the content as YAML, where double-quoted `"1481965"` remains a string.

See https://github.com/fluxcd/kustomize-controller/issues/554

Closes #627

## Test plan

- [ ] Flux reconciles `infrastructure` kustomization successfully
- [ ] `falco` HelmRelease reaches `Ready` state (b64enc no longer fails)
- [ ] Downstream kustomizations unblock (`platform-crds` → `platform` → `apps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)