### PR TITLE
fix(infra): exclude falco from infrastructure health checks (#627)

### DIFF
--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -88,10 +88,10 @@ spec:
       kind: HelmRelease
       name: arc-runner-set-packer
       namespace: packer-runners
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: falco
-      namespace: falco-system
+    # falco intentionally excluded from healthChecks. The DaemonSet
+    # runs on every node but CrashLoops on the Pi 5 (inotify handler
+    # init failure). Including it blocks the entire reconciliation chain.
+    #
     # nvidia-device-plugin intentionally excluded from healthChecks.
     # The DaemonSet has a nodeSelector (node.kubernetes.io/gpu=true) so it
     # schedules 0 pods until the GPU node joins. Including it here would


### PR DESCRIPTION
## Summary

- Falco's DaemonSet CrashLoops on the Raspberry Pi 5 node (`inotify handler init failure`), preventing the HelmRelease from reaching Ready
- This blocks the entire Flux reconciliation chain: `infrastructure` → `platform-crds` → `platform` → `apps`
- Exclude falco from health checks, same pattern as `nvidia-device-plugin` (excluded because GPU node may not exist)

Closes #627

## Test plan

- [ ] `infrastructure` kustomization reaches `Ready`
- [ ] `platform-crds` → `platform` → `apps` cascade to `Ready`
- [ ] CiliumNetworkPolicies appear: `kubectl get cnp -A`
- [ ] `kube-state-metrics` picks up version pin `<7.0.0` and stops crash-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Resolved stability issues by adjusting health check configuration to prevent crashes on specific hardware platforms and ensure uninterrupted service reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->