### PR TITLE
fix(infra): set wait: false on infrastructure kustomization to unblock chain (#627)

### DIFF
--- a/clusters/homelab/infrastructure.yaml
+++ b/clusters/homelab/infrastructure.yaml
@@ -62,7 +62,11 @@ spec:
     name: flux-system
   path: ./infrastructure/homelab
   prune: true
-  wait: true
+  # wait: false — only check explicitly listed healthChecks, not all
+  # resources. falco and nvidia-device-plugin can't reach Ready on
+  # every node (Pi 5 inotify failure, GPU node absent respectively).
+  # wait: true would block the entire reconciliation chain.
+  wait: false
   postBuild:
     substituteFrom:
       - kind: ConfigMap
@@ -88,11 +92,3 @@ spec:
       kind: HelmRelease
       name: arc-runner-set-packer
       namespace: packer-runners
-    # falco intentionally excluded from healthChecks. The DaemonSet
-    # runs on every node but CrashLoops on the Pi 5 (inotify handler
-    # init failure). Including it blocks the entire reconciliation chain.
-    #
-    # nvidia-device-plugin intentionally excluded from healthChecks.
-    # The DaemonSet has a nodeSelector (node.kubernetes.io/gpu=true) so it
-    # schedules 0 pods until the GPU node joins. Including it here would
-    # block all infrastructure reconciliation when no GPU node exists.


### PR DESCRIPTION
## Summary

- `wait: true` on the infrastructure Kustomization waits for ALL resources (including falco) to become Ready before marking the kustomization as healthy
- Falco's DaemonSet CrashLoops on the Pi 5 node (`inotify handler init failure`), so the HelmRelease never reaches Ready
- This blocks: `infrastructure` → `platform-crds` → `platform` → `apps`

**Fix**: Set `wait: false` and rely on explicit `healthChecks` for the critical HelmReleases (truenas-nfs, truenas-iscsi, arc-controller, traefik, arc-runner-set-packer). This is the same pattern needed for nvidia-device-plugin (GPU node may not exist).

Closes #627

## Test plan

- [ ] `infrastructure` kustomization reaches `Ready`
- [ ] `platform-crds` → `platform` → `apps` cascade to `Ready`
- [ ] CiliumNetworkPolicies deployed: `kubectl get cnp -A`
- [ ] kube-state-metrics picks up `<7.0.0` version pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)