### PR TITLE
fix(packer): raise inotify limits for Falco on Pi 5 nodes

### DIFF
--- a/packer/scripts/provision-k8s-node.sh
+++ b/packer/scripts/provision-k8s-node.sh
@@ -175,6 +175,12 @@ cat > /etc/sysctl.d/k8s.conf << 'EOF'
 net.bridge.bridge-nf-call-iptables  = 1
 net.bridge.bridge-nf-call-ip6tables = 1
 net.ipv4.ip_forward                 = 1
+
+# inotify: raise limits for Falco (eBPF file-event monitoring) and
+# workloads that watch many files (Flux, kubelet, etc.)
+# Raspberry Pi OS defaults are 128/8192 — far too low.
+fs.inotify.max_user_instances = 1024
+fs.inotify.max_user_watches  = 524288
 EOF
 
 sysctl --system > /dev/null 2>&1 || warn "sysctl apply skipped (OK in chroot/container)"


### PR DESCRIPTION
## Summary

Raspberry Pi OS defaults (`fs.inotify.max_user_instances=128`, `fs.inotify.max_user_watches=8192`) are too low for Falco's eBPF file-event monitoring, causing `could not initialize inotify handler` CrashLoops on Pi 5 nodes.

Raise to `1024` / `524288` in the Packer base node image. Already applied live on the Pi 5 node.

## Test plan

- [ ] Falco pod on Pi 5 stops CrashLooping after live sysctl + pod restart
- [ ] Next Packer image build includes the new sysctl values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased system-level file monitoring resource limits on Kubernetes nodes to properly support all system components and container workloads that require extensive file tracking and observation capabilities
  * Prevents resource exhaustion-related failures and performance degradation during intensive file monitoring activities
  * Improves overall Kubernetes cluster stability, reliability, and operational performance during normal operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->