### PR TITLE
fix(platform): disable cilium-healthcheck blocking reconciliation

### DIFF
--- a/platform/homelab/crds/kustomization.yaml
+++ b/platform/homelab/crds/kustomization.yaml
@@ -24,7 +24,10 @@ resources:
   - ../../base/policy-reporter
   - ../../base/node-cleanup
   - ../../base/reloader
-  - ../../base/cilium-healthcheck
+  # cilium-healthcheck disabled: registry.k8s.io/kubectl:v1.35.2 is
+  # distroless (no /bin/sh), causing CrashLoopBackOff on all nodes.
+  # Re-enable after switching to a shell-capable kubectl image.
+  # - ../../base/cilium-healthcheck
   - ../../base/alerting
 patches:
   - target:


### PR DESCRIPTION
## Summary

`registry.k8s.io/kubectl:v1.35.2` is a distroless image (no `/bin/sh`), causing the cilium-healthcheck DaemonSet to CrashLoop on all 5 nodes. With `wait: true` on platform-crds, this blocks `platform-crds` → `platform` → `apps` and prevents CiliumNetworkPolicy deployment.

Disable the healthcheck until the image is switched to a shell-capable variant (e.g. `bitnami/kubectl` or `registry.k8s.io/kubectl:v1.35.2-debian`).

## Test plan

- [ ] `platform-crds` reaches Ready
- [ ] `platform` → `apps` cascade to Ready
- [ ] CiliumNetworkPolicies deployed: `kubectl get cnp -A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)