### PR TITLE
fix(kyverno): add control-plane toleration for amd64 scheduling

### DIFF
--- a/platform/base/kyverno/helm-release.yaml
+++ b/platform/base/kyverno/helm-release.yaml
@@ -48,6 +48,10 @@ spec:
     admissionController:
       nodeSelector:
         kubernetes.io/arch: amd64
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       container:
         resources:
           requests:
@@ -67,6 +71,10 @@ spec:
     backgroundController:
       nodeSelector:
         kubernetes.io/arch: amd64
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       resources:
         requests:
           cpu: 50m
@@ -77,6 +85,10 @@ spec:
     cleanupController:
       nodeSelector:
         kubernetes.io/arch: amd64
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       resources:
         requests:
           cpu: 50m
@@ -87,6 +99,10 @@ spec:
     reportsController:
       nodeSelector:
         kubernetes.io/arch: amd64
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
       resources:
         requests:
           cpu: 50m


### PR DESCRIPTION
## Summary
- Add `tolerations` for `node-role.kubernetes.io/control-plane:NoSchedule` to all four Kyverno controllers
- Required because the only available amd64 node (kaz-k8-1) is the control-plane node
- k8-worker-1 is NotReady, k8-gpu-1 has nvidia GPU taint — both unusable
- Combined with the amd64 nodeSelector from #637, this ensures Kyverno schedules on kaz-k8-1

## Context
PR #637 added `nodeSelector: kubernetes.io/arch: amd64` but Kyverno pods stayed Pending because all amd64 nodes are tainted.

## Test plan
- [ ] Verify Kyverno pods schedule on kaz-k8-1
- [ ] Confirm admission controller stabilizes (no more liveness probe failures)
- [ ] Verify full Flux reconciliation chain reaches Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)