### PR TITLE
fix(platform): switch kubectl image to bitnami for shell support

### DIFF
--- a/platform/base/cilium-healthcheck/daemonset.yaml
+++ b/platform/base/cilium-healthcheck/daemonset.yaml
@@ -45,7 +45,7 @@ spec:
         - operator: Exists
       containers:
         - name: healthcheck
-          image: registry.k8s.io/kubectl:v1.35.2
+          image: bitnami/kubectl:1.35.2
           command:
             - /bin/sh
             - -c

--- a/platform/base/node-cleanup/cronjob.yaml
+++ b/platform/base/node-cleanup/cronjob.yaml
@@ -23,7 +23,7 @@ spec:
             - operator: Exists
           containers:
             - name: cleanup
-              image: registry.k8s.io/kubectl:v1.35.2
+              image: bitnami/kubectl:1.35.2
               command:
                 - /bin/sh
                 - -c

--- a/platform/homelab/crds/kustomization.yaml
+++ b/platform/homelab/crds/kustomization.yaml
@@ -24,10 +24,7 @@ resources:
   - ../../base/policy-reporter
   - ../../base/node-cleanup
   - ../../base/reloader
-  # cilium-healthcheck disabled: registry.k8s.io/kubectl:v1.35.2 is
-  # distroless (no /bin/sh), causing CrashLoopBackOff on all nodes.
-  # Re-enable after switching to a shell-capable kubectl image.
-  # - ../../base/cilium-healthcheck
+  - ../../base/cilium-healthcheck
   - ../../base/alerting
 patches:
   - target:


### PR DESCRIPTION
## Summary
- Switch `registry.k8s.io/kubectl:v1.35.2` (distroless, no `/bin/sh`) to `bitnami/kubectl:1.35.2` (Debian-based, has shell) in cilium-healthcheck DaemonSet and node-cleanup CronJob
- Re-enable cilium-healthcheck DaemonSet in platform-crds kustomization (was disabled in #636)

## Test plan
- [ ] Verify cilium-healthcheck DaemonSet pods start without CrashLoopBackOff
- [ ] Verify node-cleanup CronJob runs successfully on next schedule
- [ ] Confirm platform-crds reconciliation chain is unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)