### PR TITLE
fix(platform): use healthChecks for platform-crds and add kyverno cluster egress

### DIFF
--- a/clusters/dev/platform.yaml
+++ b/clusters/dev/platform.yaml
@@ -13,7 +13,15 @@ spec:
     name: flux-system
   path: ./platform/dev/crds
   prune: true
-  wait: true
+  # wait: false — only check explicitly listed healthChecks, not all
+  # resources. DaemonSets (grafana-alloy) on unreachable nodes stay
+  # Unknown indefinitely; wait: true would block the entire chain.
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kyverno
+      namespace: kyverno-system
   dependsOn:
     - name: infrastructure
   postBuild:

--- a/clusters/homelab/platform.yaml
+++ b/clusters/homelab/platform.yaml
@@ -30,7 +30,35 @@ spec:
     name: flux-system
   path: ./platform/homelab/crds
   prune: true
-  wait: true
+  # wait: false — only check explicitly listed healthChecks, not all
+  # resources. DaemonSets (grafana-alloy, cilium-healthcheck) on
+  # unreachable nodes stay Unknown indefinitely; wait: true would
+  # block the entire chain.
+  # NOTE: on fresh bootstrap the Kyverno HelmRelease may report Ready
+  # before the API server discovery cache registers Kyverno CRDs.
+  # The platform Kustomization's retryInterval (1m) self-heals this.
+  wait: false
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kyverno
+      namespace: kyverno-system
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: kube-state-metrics
+      namespace: monitoring
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: backstage
+      namespace: backstage
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: policy-reporter
+      namespace: policy-reporter
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: reloader
+      namespace: reloader
   dependsOn:
     - name: infrastructure
   postBuild:

--- a/platform/base/network-policies/kyverno-system.yaml
+++ b/platform/base/network-policies/kyverno-system.yaml
@@ -5,7 +5,9 @@
 # Kubernetes API server calls Kyverno's webhook endpoints when
 # resources are created/modified, so Kyverno needs ingress from
 # the API server. Kyverno also needs egress to the API server to
-# watch policy resources and generate reports.
+# watch policy resources and generate reports. The four controllers
+# (admission, background, cleanup, reports) also need cluster-wide
+# egress for cross-namespace operations and leader election.
 # ══════════════════════════════════════════════════════════════════
 ---
 apiVersion: cilium.io/v2
@@ -39,6 +41,22 @@ spec:
   egress:
     - toEntities:
         - kube-apiserver
+---
+# Kyverno controllers need cluster-wide egress: the background controller
+# watches and mutates resources in all namespaces, the reports controller
+# generates PolicyReports in target namespaces, and the cleanup controller
+# removes expired resources cluster-wide. Leader election (intra-namespace)
+# is also covered by this rule.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: kyverno-system-allow-egress-cluster
+  namespace: kyverno-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - cluster
 ---
 # Allow cluster-internal ingress for Prometheus metrics scraping
 apiVersion: cilium.io/v2


### PR DESCRIPTION
## Summary
- **platform-crds**: Switch from `wait: true` to `wait: false` with explicit `healthChecks` for the Kyverno HelmRelease. DaemonSets (e.g. grafana-alloy) on unreachable nodes report `Unknown` indefinitely, blocking the entire Flux dependency chain (`platform-crds` → `platform`).
- **kyverno-system netpol**: Add `kyverno-system-allow-egress-cluster` CiliumNetworkPolicy so the four Kyverno controllers (admission, background, cleanup, reports) can coordinate via leader election and internal APIs. Found during PR #624 code review.

## Test plan
- [ ] Verify `platform-crds` Kustomization reconciles without blocking on unhealthy DaemonSets
- [ ] Verify `platform` Kustomization still waits for Kyverno to be ready (via healthChecks)
- [ ] Check Hubble for kyverno-system audit drops — should see no new violations from controller-to-controller traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized deployment wait behavior to prevent blocking on unreachable resources while ensuring critical component health verification.

* **Chores**
  * Enhanced network security policies for component cluster communication.
  * Improved platform configuration for controller coordination and health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->