### PR TITLE
fix(kyverno): add GPU node toleration for all controllers (#645)

### DIFF
--- a/platform/base/kyverno/helm-release.yaml
+++ b/platform/base/kyverno/helm-release.yaml
@@ -49,7 +49,7 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
       tolerations:
-        - key: node-role.kubernetes.io/control-plane
+        - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
       container:
@@ -72,7 +72,7 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
       tolerations:
-        - key: node-role.kubernetes.io/control-plane
+        - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
       resources:
@@ -86,7 +86,7 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
       tolerations:
-        - key: node-role.kubernetes.io/control-plane
+        - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
       resources:
@@ -100,7 +100,7 @@ spec:
       nodeSelector:
         kubernetes.io/arch: amd64
       tolerations:
-        - key: node-role.kubernetes.io/control-plane
+        - key: nvidia.com/gpu
           operator: Exists
           effect: NoSchedule
       resources:


### PR DESCRIPTION
## Summary
- Adds `nvidia.com/gpu` toleration to all four Kyverno controllers so they can schedule on the GPU node
- Removes the previous control-plane toleration to keep Kyverno off kaz-k8-1
- k8-worker-1 (the other amd64 node) experiences transient RCU stalls during host backups, so having the GPU node as a fallback prevents Kyverno from getting stuck

Closes #645

## Test plan
- [ ] Verify Kyverno pods schedule on k8-worker-1 or the GPU node
- [ ] Confirm no pods land on the control plane node (kaz-k8-1)
- [ ] Check admission webhook is reachable after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)