### PR TITLE
fix(netpol): use enableDefaultDeny instead of empty ingress/egress arrays

### DIFF
--- a/platform/base/network-policies/arc-runners.yaml
+++ b/platform/base/network-policies/arc-runners.yaml
@@ -14,8 +14,12 @@ metadata:
   namespace: arc-runners
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — arc-runners has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/base/network-policies/arc-system.yaml
+++ b/platform/base/network-policies/arc-system.yaml
@@ -13,8 +13,12 @@ metadata:
   namespace: arc-system
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — arc-system has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 # ARC controller needs GitHub API access to manage runner registrations
 apiVersion: cilium.io/v2

--- a/platform/base/network-policies/backstage.yaml
+++ b/platform/base/network-policies/backstage.yaml
@@ -10,16 +10,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: backstage-default-deny
-  namespace: backstage
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: backstage-allow-ingress-traefik
   namespace: backstage
 spec:

--- a/platform/base/network-policies/crossplane-system.yaml
+++ b/platform/base/network-policies/crossplane-system.yaml
@@ -9,16 +9,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: crossplane-system-default-deny
-  namespace: crossplane-system
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: crossplane-system-allow-egress-kube-api
   namespace: crossplane-system
 spec:

--- a/platform/base/network-policies/democratic-csi.yaml
+++ b/platform/base/network-policies/democratic-csi.yaml
@@ -15,8 +15,12 @@ metadata:
   namespace: democratic-csi
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — democratic-csi has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/base/network-policies/flux-system.yaml
+++ b/platform/base/network-policies/flux-system.yaml
@@ -11,16 +11,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: flux-system-default-deny
-  namespace: flux-system
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: flux-system-allow-egress-github
   namespace: flux-system
 spec:

--- a/platform/base/network-policies/kyverno-system.yaml
+++ b/platform/base/network-policies/kyverno-system.yaml
@@ -13,16 +13,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: kyverno-system-default-deny
-  namespace: kyverno-system
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: kyverno-system-allow-ingress-kube-api
   namespace: kyverno-system
 spec:

--- a/platform/base/network-policies/monitoring.yaml
+++ b/platform/base/network-policies/monitoring.yaml
@@ -11,16 +11,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: monitoring-default-deny
-  namespace: monitoring
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: monitoring-allow-egress-cluster
   namespace: monitoring
 spec:

--- a/platform/base/network-policies/nvidia-device-plugin.yaml
+++ b/platform/base/network-policies/nvidia-device-plugin.yaml
@@ -14,8 +14,12 @@ metadata:
   namespace: nvidia-device-plugin
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — nvidia-device-plugin has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/base/network-policies/onepassword-system.yaml
+++ b/platform/base/network-policies/onepassword-system.yaml
@@ -14,8 +14,12 @@ metadata:
   namespace: onepassword-system
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — onepassword-system has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/base/network-policies/packer-runners.yaml
+++ b/platform/base/network-policies/packer-runners.yaml
@@ -13,8 +13,12 @@ metadata:
   namespace: packer-runners
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — packer-runners has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/base/network-policies/policy-reporter.yaml
+++ b/platform/base/network-policies/policy-reporter.yaml
@@ -11,16 +11,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: policy-reporter-default-deny
-  namespace: policy-reporter
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: policy-reporter-allow-ingress-backstage
   namespace: policy-reporter
 spec:

--- a/platform/base/network-policies/reloader.yaml
+++ b/platform/base/network-policies/reloader.yaml
@@ -14,8 +14,12 @@ metadata:
   namespace: reloader
 spec:
   endpointSelector: {}
-  ingress: []
-  egress: []
+  # Explicit ingress deny — reloader has no inbound connections.
+  # ingressDeny takes precedence over ingress allow rules; safe here
+  # because no ingress allow policies exist for this namespace.
+  ingressDeny:
+    - fromEntities:
+        - all
 ---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/platform/base/network-policies/traefik-system.yaml
+++ b/platform/base/network-policies/traefik-system.yaml
@@ -11,16 +11,6 @@
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: traefik-system-default-deny
-  namespace: traefik-system
-spec:
-  endpointSelector: {}
-  ingress: []
-  egress: []
----
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
   name: traefik-system-allow-ingress-world
   namespace: traefik-system
 spec:


### PR DESCRIPTION
## Summary
- All 14 default-deny CiliumNetworkPolicy resources were `VALID: False` — Cilium 1.19.1 rejects empty `ingress: []` / `egress: []` arrays and standalone `enableDefaultDeny` without rule stanzas
- **7 bidirectional namespaces** (backstage, crossplane, flux, kyverno, monitoring, policy-reporter, traefik): Removed redundant default-deny policies — the existing ingress + egress allow policies already activate Cilium's implicit default deny for both directions
- **7 egress-only namespaces** (arc-runners, arc-system, democratic-csi, nvidia-device-plugin, onepassword-system, packer-runners, reloader): Replaced with explicit `ingressDeny: [{fromEntities: [all]}]` — these namespaces have no inbound connections and no ingress allow rules, so the deny-takes-precedence behaviour is safe

## Test plan
- [ ] Verify all policies show `VALID: True` after reconciliation
- [ ] Confirm `cilium-dbg endpoint list` shows `Enabled Enabled` for both ingress/egress on all managed endpoints
- [ ] Check Hubble for new AUDIT violations from newly-active ingress deny on the 7 egress-only namespaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)