### PR TITLE
feat(falco): add falcosidekick-ui with Traefik ingress

### DIFF
--- a/infrastructure/base/falco/helm-release.yaml
+++ b/infrastructure/base/falco/helm-release.yaml
@@ -24,8 +24,12 @@ spec:
       interval: 1h
   install:
     timeout: 10m
+    remediation:
+      retries: 3
   upgrade:
     timeout: 10m
+    remediation:
+      retries: 3
 
   # Inject Grafana Cloud API key from the 1Password-synced secret
   # into Falcosidekick's Loki config. The key never appears in Git.
@@ -94,7 +98,8 @@ spec:
 
       # ── Falcosidekick UI ────────────────────────────────────────────
       # Web dashboard for browsing Falco events in real time.
-      # Exposed externally via Traefik IngressRoute.
+      # Event storage is ephemeral (Redis with no PVC) — events are
+      # lost on pod restart. Loki is the durable store.
       webui:
         enabled: true
         replicaCount: 1
@@ -105,3 +110,11 @@ spec:
           limits:
             cpu: 200m
             memory: 128Mi
+        redis:
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 100m
+              memory: 128Mi

--- a/platform/base/network-policies/falco-system.yaml
+++ b/platform/base/network-policies/falco-system.yaml
@@ -1,0 +1,65 @@
+# ══════════════════════════════════════════════════════════════════
+# falco-system — Runtime Security Monitoring
+#
+# Falco runs as a DaemonSet detecting anomalous container behaviour.
+# Falcosidekick forwards events to Grafana Cloud Loki.
+# Falcosidekick-UI provides a web dashboard exposed via Traefik.
+# ══════════════════════════════════════════════════════════════════
+---
+# Allow Traefik to reach falcosidekick-ui on its service port
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: falco-allow-ingress-traefik-ui
+  namespace: falco-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: traefik-system
+      toPorts:
+        - ports:
+            - port: "2802"
+              protocol: TCP
+---
+# Allow intra-namespace traffic (UI ↔ Redis)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: falco-allow-ingress-intra-namespace
+  namespace: falco-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: falco-system
+---
+# Falcosidekick needs HTTPS egress to push events to Grafana Cloud Loki
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: falco-allow-egress-grafana-cloud
+  namespace: falco-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toFQDNs:
+        - matchPattern: "*.grafana.net"
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# Allow cluster-internal egress (DNS, Kubernetes API)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: falco-allow-egress-cluster
+  namespace: falco-system
+spec:
+  endpointSelector: {}
+  egress:
+    - toEntities:
+        - cluster

--- a/platform/base/network-policies/kustomization.yaml
+++ b/platform/base/network-policies/kustomization.yaml
@@ -30,3 +30,4 @@ resources:
   - onepassword-system.yaml
   - kyverno-system.yaml
   - crossplane-system.yaml
+  - falco-system.yaml

--- a/platform/base/traefik-config/external-services.yaml
+++ b/platform/base/traefik-config/external-services.yaml
@@ -137,6 +137,9 @@ spec:
 
 ---
 # ── Falco UI (in-cluster, falco-system namespace) ────────────────
+# Service name derived from HelmRelease "falco" + chart template:
+#   falco-falcosidekick-ui.falco-system.svc.cluster.local
+# Update externalName if the HelmRelease name changes.
 apiVersion: v1
 kind: Service
 metadata:

--- a/platform/base/traefik-config/ingressroutes.yaml
+++ b/platform/base/traefik-config/ingressroutes.yaml
@@ -324,6 +324,7 @@ spec:
           port: 2802
       middlewares:
         - name: security-headers
+        - name: dashboard-auth
   tls:
     certResolver: letsencrypt
 


### PR DESCRIPTION
## Summary
- Enable falcosidekick-ui web dashboard for browsing Falco runtime security events
- Add Traefik IngressRoute at `falco.lab.kazie.co.uk` with TLS, security headers, and basic auth via 1Password
- Add CiliumNetworkPolicy for `falco-system` namespace (Traefik ingress, intra-namespace, Grafana Cloud egress)
- Add Redis resource limits and Flux install/upgrade remediation

## Test plan
- [ ] Verify Flux reconciles the Falco HelmRelease with webui enabled
- [ ] Confirm `falco-falcosidekick-ui` service is created in `falco-system`
- [ ] Verify `falco.lab.kazie.co.uk` resolves and prompts for basic auth
- [ ] Confirm Cloudflare A record is created by dns-cloudflare-sync workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled Falco UI web interface with persistent storage capabilities.
  * Added Flux Operator WebUI for cluster administration.
  * Configured network security policies to control inter-service communication and external access.
  * Implemented automatic retry handling for improved system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->