### PR TITLE
docs: sync documentation with recent Falco, Kyverno, and NetworkPolicy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ full procedure, or run `python3 scripts/bootstrap.py` for automated setup.
 | [`docs/runbooks/secrets-management.md`](docs/runbooks/secrets-management.md) | 1Password secrets lifecycle |
 | [`docs/runbooks/truenas-setup.md`](docs/runbooks/truenas-setup.md) | TrueNAS CSI configuration |
 | [`docs/traefik-tls-migration.md`](docs/traefik-tls-migration.md) | Caddy→Traefik migration & ACME fix |
-| [`docs/adr/`](docs/adr/) | Architecture Decision Records (001–008) |
+| [`docs/adr/`](docs/adr/) | Architecture Decision Records (001–010) |
 | [`docs/learning/`](docs/learning/) | Deep-dive educational content |

--- a/docs/adr/008-cni-replacement-networkpolicy.md
+++ b/docs/adr/008-cni-replacement-networkpolicy.md
@@ -205,8 +205,30 @@ Cilium's L7 policies could theoretically replace some Traefik middleware (e.g., 
 
 Every namespace gets a default-deny CiliumNetworkPolicy. Pods that need network access get explicit allowlists. This is the only defensible posture for a control-plane cluster.
 
+> **Correction (2026-03-05):** The original template below with empty `ingress: []` /
+> `egress: []` arrays is **invalid** in Cilium 1.19.1. Cilium rejects
+> CiliumNetworkPolicy resources that have empty rule arrays AND standalone
+> `enableDefaultDeny` without rule stanzas. All 14 default-deny policies
+> using this template were `VALID: False` and not enforced.
+>
+> The corrected approach depends on whether the namespace has allow policies:
+>
+> - **Namespaces with both ingress and egress allow policies** (e.g.
+>   backstage, flux-system, traefik-system): No standalone default-deny
+>   policy needed. The presence of an ingress/egress allow policy
+>   implicitly activates Cilium's default deny for that direction.
+>
+> - **Egress-only namespaces with no inbound connections** (e.g.
+>   arc-runners, democratic-csi, onepassword-system): Use explicit
+>   `ingressDeny: [{fromEntities: [all]}]` to deny ingress. The egress
+>   allow policies already activate egress default deny implicitly.
+>
+> See commit 41ec178 (`fix(netpol): fix invalid default-deny policies
+> across all namespaces (#646)`) for the full fix.
+
 ```yaml
-# Template: default-deny for every namespace
+# DEPRECATED — this template is invalid in Cilium 1.19.1.
+# See correction note above for the valid approaches.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ source of truth, reconciled by Kubernetes-native controllers.
     │  │ 1Password │  │ (→ Backstage)    │  │
     │  │ Operator  │  │ (→ Crossplane)   │  │
     │  │ GHA Runner│  │                  │  │
+    │  │ Falco     │  │                  │  │
     │  └──────────┘  └──────────────────┘  │
     │                                      │
     │  ┌──────────────────────────────────┐│
@@ -52,7 +53,7 @@ healthy before the next begins:
 
 | Layer | Directory         | Contents                          | Depends On     |
 |-------|-------------------|-----------------------------------|----------------|
-| 1     | `infrastructure/` | Cilium, Traefik, 1Password, democratic-csi, Flux addons | —  |
+| 1     | `infrastructure/` | Cilium, Traefik, 1Password, democratic-csi, Falco, Flux addons | —  |
 | 2a    | `platform/crds`   | Kyverno HelmRelease, Grafana Alloy | Infrastructure |
 | 2b    | `platform/policies`| Kyverno ClusterPolicies           | Platform CRDs  |
 | 3     | `apps/`           | Diixtra services (future)         | Platform       |
@@ -133,6 +134,21 @@ This separates the monitoring failure domain from the cluster failure domain.
 If the cluster is down, Grafana Cloud still has all historical data and
 can alert on the absence of new data.
 
+## Runtime Security
+
+- **Falco**: eBPF-based runtime security monitoring. DaemonSet on every amd64
+  node detecting anomalous container behaviour (shell spawns, sensitive file
+  reads, privilege escalation) using the modern eBPF driver.
+- **Falcosidekick**: Forwards Falco events to Grafana Cloud Loki for
+  centralised alerting and dashboarding.
+- **Falcosidekick-UI**: Web dashboard for browsing Falco events in real time
+  at `falco.lab.kazie.co.uk`. Exposed via Traefik IngressRoute with
+  basic-auth middleware (1Password-synced credential). Event storage is
+  ephemeral (Redis, no PVC) — Loki is the durable store.
+- **CiliumNetworkPolicy**: falco-system namespace has explicit policies
+  allowing Traefik ingress on port 2802, intra-namespace traffic (UI ↔ Redis),
+  and egress to Grafana Cloud Loki.
+
 ## Storage (ADR-006)
 
 - **democratic-csi** with TrueNAS SCALE at 10.2.0.232
@@ -149,7 +165,7 @@ can alert on the absence of new data.
 | 2     | Policy enforcement, supply chain| Kyverno, Trivy, Cosign |
 | 3     | Developer self-service         | Backstage              |
 | 4     | Declarative everything         | Crossplane, UniFi API  |
-| 5     | Runtime security               | Falco, CSI driver, NetworkPolicies |
+| 5     | Runtime security (in progress)  | Falco ✓, NetworkPolicies ✓, CSI driver |
 
 See `docs/adr/005-auto-update-strategy.md` for detailed phase descriptions.
 
@@ -181,6 +197,7 @@ See `docs/adr/005-auto-update-strategy.md` for detailed phase descriptions.
 | Document                        | Purpose                                        |
 |---------------------------------|------------------------------------------------|
 | `traefik-tls-migration.md`     | Caddy→Traefik migration, ACME DNS-01 root cause & fix |
+| `kyverno-webhook-timeout-cascade.md` | Kyverno fail-closed webhook blocking Flux reconciliation |
 
 ## Repository Structure
 
@@ -208,6 +225,7 @@ diixtra-forge/
 │   │   ├── cilium/          CNI (eBPF), kube-proxy replacement, L2 LB (ADR-008)
 │   │   ├── traefik/
 │   │   ├── democratic-csi/  NFS + iSCSI (dataset paths: OVERRIDE_IN_ENV_PATCH)
+│   │   ├── falco/           Runtime security (eBPF), Falcosidekick → Loki, UI
 │   │   ├── onepassword-operator/
 │   │   ├── github-actions-runner/  Self-hosted ARC runner (homelab)
 │   │   ├── packer-runner/   Privileged ARC runner for Packer Pi builds

--- a/docs/homelab-ops-commands.md
+++ b/docs/homelab-ops-commands.md
@@ -109,6 +109,10 @@ Quick reference for all operational commands used to manage the diixtra-forge ho
 | debug-flux-helm | `kubectl logs -n flux-system deploy/helm-controller` | debug, flux |
 | debug-flux-image-reflect | `kubectl logs -n flux-system deploy/image-reflector-controller` | debug, flux |
 | debug-flux-image-auto | `kubectl logs -n flux-system deploy/image-automation-controller` | debug, flux |
+| debug-falco | `kubectl logs -n falco-system ds/falco --tail=50` | debug, falco |
+| debug-falcosidekick | `kubectl logs -n falco-system deploy/falco-falcosidekick --tail=50` | debug, falco |
+| debug-falco-ui | `kubectl logs -n falco-system deploy/falco-falcosidekick-ui --tail=50` | debug, falco |
+| falco-events | `kubectl logs -n falco-system ds/falco --tail=20 \| grep -E 'Warning\|Error\|Critical'` | debug, falco |
 | helm-history | `helm history {{name}} -n {{namespace}}` | debug, helm |
 | pvc-status | `kubectl get pvc -A` | debug, storage |
 | describe-onepassworditem | `kubectl describe onepassworditem {{name}} -n {{namespace}}` | debug, 1password |
@@ -132,7 +136,7 @@ Quick reference for all operational commands used to manage the diixtra-forge ho
 
 ---
 
-**Total: 69 commands across 11 categories**
+**Total: 73 commands across 11 categories**
 
 ### Template Variables
 

--- a/docs/troubleshooting/kyverno-webhook-timeout-cascade.md
+++ b/docs/troubleshooting/kyverno-webhook-timeout-cascade.md
@@ -1,0 +1,82 @@
+# Kyverno Webhook Timeout Cascade — Flux Reconciliation Blocked
+
+**Date:** 2026-03-05
+**Affected Components:** Kyverno, Flux CD (all controllers)
+**Impact:** When Kyverno is unhealthy, its fail-closed validating webhook times out on every Flux dry-run, blocking the entire reconciliation chain — including flux-system itself.
+**Root Cause:** Kyverno's webhook is called by the API server for every dry-run, even in namespaces where no Enforce policies apply.
+
+## Symptoms
+
+- All Flux Kustomizations stuck in `Not Ready` with timeout errors
+- `flux get kustomizations` shows errors like `context deadline exceeded`
+- Kyverno pods crash-looping or not ready
+- Manual `kubectl` operations in affected namespaces hang for 30 seconds before failing
+
+## Root Cause
+
+Kyverno's validating webhook uses `failurePolicy: Fail` (fail-closed). The API server calls this webhook for **every** dry-run and create/update operation across all namespaces. When Kyverno is unhealthy (crash loop, startup, OOM), the webhook times out (default 30s) and the API server rejects the request.
+
+Flux controllers perform dry-runs during every reconciliation cycle. When the webhook times out, the dry-run fails, and Flux marks the Kustomization as `Not Ready`. This affects **all** Flux Kustomizations — including the infrastructure layer that deploys Kyverno itself — creating a circular dependency.
+
+The critical distinction:
+
+| Mechanism | How it works | When Kyverno is down |
+|---|---|---|
+| `config.resourceFilters` | Kyverno receives the request and returns immediate allow | **Still blocks** — Kyverno must be reachable |
+| `config.webhooks.namespaceSelector` | API server skips the webhook entirely for excluded namespaces | **Works** — API server never calls Kyverno |
+
+Only the `namespaceSelector` approach prevents timeouts when Kyverno is completely unreachable.
+
+## Fix Applied
+
+Added a `namespaceSelector` to Kyverno's webhook configuration in `platform/base/kyverno/helm-release.yaml`:
+
+```yaml
+config:
+  webhooks:
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - kyverno-system
+            - kube-system
+            - flux-system
+            - monitoring
+            - democratic-csi
+```
+
+This tells the API server to skip the Kyverno webhook entirely for these namespaces. The namespaces were chosen because every Enforce policy in `kyverno-policies/` already excludes them.
+
+**Helm chart syntax note:** The Kyverno Helm chart expects `config.webhooks` as a map, not a list. Using list syntax (`- namespaceSelector:`) silently fails to apply the exclusion.
+
+See: commit 8b78780 (`fix(kyverno): exclude system namespaces from webhook to prevent timeout cascade (#650)`)
+
+## Important Caveat
+
+If you add a new Enforce policy to `kyverno-policies/`, verify its `exclude` list covers the namespaces listed in the webhook selector above. Otherwise, the webhook exclusion creates a gap where the policy is not enforced in those namespaces but the policy's exclude list doesn't explicitly account for it.
+
+## Diagnostic Commands
+
+```bash
+# Check if Kyverno webhook is configured with namespace exclusions
+kubectl get validatingwebhookconfigurations -l app.kubernetes.io/instance=kyverno -o yaml | grep -A 10 namespaceSelector
+
+# Check Kyverno pod health
+kubectl get pods -n kyverno-system
+
+# Test if dry-runs work in an excluded namespace (should succeed even if Kyverno is down)
+kubectl create deployment test --image=nginx --dry-run=server -n flux-system
+
+# Test if dry-runs work in a non-excluded namespace (will timeout if Kyverno is down)
+kubectl create deployment test --image=nginx --dry-run=server -n backstage
+
+# Check Flux reconciliation status
+flux get kustomizations
+```
+
+## Prevention
+
+1. The webhook `namespaceSelector` ensures that critical system namespaces (flux-system, kube-system) are never blocked by Kyverno outages.
+2. Kyverno is scheduled on amd64 nodes only — Pi nodes lack sufficient memory for the admission controller.
+3. Kyverno has GPU node tolerations to allow scheduling flexibility.


### PR DESCRIPTION
## Documentation Update — 2026-03-05

Automated documentation review of the last 24 hours of commits. 28 commits were analyzed; 3 significant changes triggered documentation updates.

### Changes Made

**1. Falco Runtime Security — `docs/architecture.md`**
- Added new "Runtime Security" section documenting Falco, Falcosidekick, and Falcosidekick-UI
- Added Falco to architecture diagram, deployment layers table, and repository structure
- Updated Evolution Roadmap Phase 5 to show "in progress" with Falco ✓ and NetworkPolicies ✓
- Added troubleshooting doc link to the index

Triggered by: 70c1715 `feat(falco): add falcosidekick-ui with Traefik ingress (#657)`

**2. Kyverno Webhook Timeout Cascade — new troubleshooting doc**
- Created `docs/troubleshooting/kyverno-webhook-timeout-cascade.md`
- Documents the fail-closed webhook blocking all Flux dry-runs when Kyverno is unhealthy
- Explains the difference between `resourceFilters` (still blocks) vs `namespaceSelector` (prevents timeouts)
- Includes diagnostic commands and prevention guidance

Triggered by: 8b78780 `fix(kyverno): exclude system namespaces from webhook to prevent timeout cascade (#650)`

**3. ADR-008 Default-Deny Correction — `docs/adr/008-cni-replacement-networkpolicy.md`**
- Added correction note to the NetworkPolicy Strategy section
- Documents that Cilium 1.19.1 rejects empty `ingress: []` / `egress: []` arrays
- Describes the two valid approaches: implicit deny via allow policies, and explicit `ingressDeny`

Triggered by: 41ec178 `fix(netpol): fix invalid default-deny policies across all namespaces (#646)`

**4. Falco Ops Commands — `docs/homelab-ops-commands.md`**
- Added 4 new Falco debugging commands (debug-falco, debug-falcosidekick, debug-falco-ui, falco-events)
- Updated total command count from 69 to 73

**5. README.md**
- Updated ADR range from 001–008 to 001–010

### Commits Skipped (no docs needed)

- 18 automated image updates and dependency bumps (`chore(images)`, `chore(deps)`)
- 7 iterative bug fixes (falco resource limits, kyverno tolerations, storage switches, health check exclusions)

_This PR was generated with [Oz](https://www.warp.dev/oz)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Architecture Decision Records reference (001–010)
  * Added clarification on network policy configuration requirements and best practices
  * Introduced new troubleshooting guide for webhook timeout issues and remediation steps
  * Expanded debug command reference with additional troubleshooting utilities for runtime security components
  * Enhanced architecture documentation with runtime security tooling details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->