### PR TITLE
fix(ci): install kubectl on ARC runners and fix Cloudflare DNS IP extraction

### DIFF
--- a/.github/workflows/cluster-health-gate.yaml
+++ b/.github/workflows/cluster-health-gate.yaml
@@ -21,9 +21,14 @@ jobs:
     steps:
       - name: Install kubectl
         run: |
+          set -euo pipefail
           if ! command -v kubectl &> /dev/null; then
-            curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+            KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+            curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
             chmod +x /usr/local/bin/kubectl
+            echo "kubectl installed: $(kubectl version --client)"
+          else
+            echo "kubectl already available: $(kubectl version --client)"
           fi
 
       - name: Check cluster health

--- a/.github/workflows/dns-cloudflare-sync.yaml
+++ b/.github/workflows/dns-cloudflare-sync.yaml
@@ -10,7 +10,6 @@ on:
     paths:
       - 'platform/base/traefik-config/**'
       - 'clusters/homelab/vars.yaml'
-      - 'infrastructure/base/traefik/helm-release.yaml'
   workflow_dispatch: {}
 
 concurrency:
@@ -93,7 +92,13 @@ jobs:
           # Look up Cloudflare zone ID from domain name
           ZONE_ID=$(curl -sf -H "Authorization: Bearer $CF_API_TOKEN" \
             "https://api.cloudflare.com/client/v4/zones?name=$DOMAIN" \
-            | jq -r '.result[0].id')
+            | jq -r '.result[0].id // empty')
+
+          if [ -z "$ZONE_ID" ]; then
+            echo "::error::Cloudflare zone not found for domain '$DOMAIN'"
+            echo "Verify CF_API_TOKEN has Zone:Read permission and the domain exists in this Cloudflare account"
+            exit 1
+          fi
 
           echo "Zone: $DOMAIN ($ZONE_ID)"
           echo "Target IP: $LB_IP"
@@ -110,12 +115,16 @@ jobs:
 
             if [ "$COUNT" -eq 0 ]; then
               echo "++ Creating: $HOST -> $LB_IP"
-              curl -sf -X POST \
+              RESULT=$(curl -sf -X POST \
                 -H "Authorization: Bearer $CF_API_TOKEN" \
                 -H "Content-Type: application/json" \
                 "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records" \
-                -d "{\"type\":\"A\",\"name\":\"$HOST\",\"content\":\"$LB_IP\",\"ttl\":1,\"proxied\":false}" \
-                | jq '{success: .success, id: .result.id}'
+                -d "{\"type\":\"A\",\"name\":\"$HOST\",\"content\":\"$LB_IP\",\"ttl\":1,\"proxied\":false}")
+              if [ "$(echo "$RESULT" | jq -r '.success')" != "true" ]; then
+                echo "::error::Failed to create A record for $HOST: $(echo "$RESULT" | jq -r '.errors[]?.message // "unknown error"')"
+                exit 1
+              fi
+              echo "$RESULT" | jq '{success: .success, id: .result.id}'
               CREATED=$((CREATED + 1))
             else
               echo "== Exists:   $HOST"

--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -25,12 +25,14 @@ jobs:
     steps:
       - name: Install kubectl
         run: |
+          set -euo pipefail
           if ! command -v kubectl &> /dev/null; then
-            curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
+            KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
+            curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
             chmod +x /usr/local/bin/kubectl
-            echo "kubectl installed: $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+            echo "kubectl installed: $(kubectl version --client)"
           else
-            echo "kubectl already available: $(kubectl version --client --short 2>/dev/null || kubectl version --client)"
+            echo "kubectl already available: $(kubectl version --client)"
           fi
 
       - name: Pre-flight — API server reachable


### PR DESCRIPTION
## Summary
- **Post-deploy check & cluster health gate**: Added `Install kubectl` step — the ARC runner image (`ghcr.io/actions/actions-runner:latest`) doesn't include kubectl, so every run failed at the first step with "API server unreachable"
- **Cloudflare DNS sync**: Fixed LB IP extraction — the script searched for `loadBalancerIPs:` in the Traefik HelmRelease but the actual value is a Flux variable (`${LB_TRAEFIK_IP}`). Now reads the IP directly from `clusters/homelab/vars.yaml`. Added early validation to fail with a clear error if domain or IP is missing.

## Test plan
- [ ] Merge and verify post-deploy health check passes the preflight step
- [ ] Trigger Cloudflare DNS sync manually via `workflow_dispatch` and confirm it syncs records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated kubectl installation in cluster health verification and post-deployment monitoring workflows to improve reliability across all automation processes
  * Consolidated infrastructure configuration sourcing by migrating from file-based parsing to centralized cluster variables for better maintainability and consistency
  * Strengthened automation safety by adding validation checks for required configuration parameters, preventing incomplete or failed deployments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->