### PR TITLE
fix(ci): install kubectl to writable path on non-root ARC runners

### DIFF
--- a/.github/workflows/cluster-health-gate.yaml
+++ b/.github/workflows/cluster-health-gate.yaml
@@ -24,9 +24,12 @@ jobs:
           set -euo pipefail
           if ! command -v kubectl &> /dev/null; then
             KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
-            curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
-            chmod +x /usr/local/bin/kubectl
-            echo "kubectl installed: $(kubectl version --client)"
+            BIN_DIR="${RUNNER_TEMP:-/tmp}/bin"
+            mkdir -p "$BIN_DIR"
+            curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o "$BIN_DIR/kubectl"
+            chmod +x "$BIN_DIR/kubectl"
+            echo "$BIN_DIR" >> "$GITHUB_PATH"
+            echo "kubectl installed: $("$BIN_DIR/kubectl" version --client)"
           else
             echo "kubectl already available: $(kubectl version --client)"
           fi

--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -28,9 +28,12 @@ jobs:
           set -euo pipefail
           if ! command -v kubectl &> /dev/null; then
             KUBECTL_VERSION=$(curl -fsSL https://dl.k8s.io/release/stable.txt)
-            curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl
-            chmod +x /usr/local/bin/kubectl
-            echo "kubectl installed: $(kubectl version --client)"
+            BIN_DIR="${RUNNER_TEMP:-/tmp}/bin"
+            mkdir -p "$BIN_DIR"
+            curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o "$BIN_DIR/kubectl"
+            chmod +x "$BIN_DIR/kubectl"
+            echo "$BIN_DIR" >> "$GITHUB_PATH"
+            echo "kubectl installed: $("$BIN_DIR/kubectl" version --client)"
           else
             echo "kubectl already available: $(kubectl version --client)"
           fi


### PR DESCRIPTION
## Summary
- ARC runner pods run as UID 1001 (non-root), so `curl -o /usr/local/bin/kubectl` fails with exit code 23 ("Failure writing output to destination")
- Installs kubectl to `$RUNNER_TEMP/bin` instead and adds it to `$GITHUB_PATH`
- Fixes both `post-deploy-check.yaml` and `cluster-health-gate.yaml`

## Test plan
- [ ] Merge and verify the "Install kubectl" step passes on the next post-deploy run

🤖 Generated with [Claude Code](https://claude.com/claude-code)