### PR TITLE
fix(security): add missing securityContext for restricted PSS compliance

### DIFF
--- a/apps/base/mcp-servers/cloudflare/deployment.yaml
+++ b/apps/base/mcp-servers/cloudflare/deployment.yaml
@@ -70,3 +70,5 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/base/mcp-servers/grafana/deployment.yaml
+++ b/apps/base/mcp-servers/grafana/deployment.yaml
@@ -68,3 +68,5 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/base/mcp-servers/kubernetes/deployment.yaml
+++ b/apps/base/mcp-servers/kubernetes/deployment.yaml
@@ -50,3 +50,5 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/base/mcp-servers/memory/deployment.yaml
+++ b/apps/base/mcp-servers/memory/deployment.yaml
@@ -73,6 +73,8 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault
       volumes:
         - name: memory-data
           persistentVolumeClaim:

--- a/apps/base/mcp-servers/stripe/deployment.yaml
+++ b/apps/base/mcp-servers/stripe/deployment.yaml
@@ -72,3 +72,5 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/base/mcp-servers/terraform/deployment.yaml
+++ b/apps/base/mcp-servers/terraform/deployment.yaml
@@ -51,3 +51,5 @@ spec:
             capabilities:
               drop:
                 - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/platform/base/graphite-exporter/deployment.yaml
+++ b/platform/base/graphite-exporter/deployment.yaml
@@ -33,6 +33,14 @@ spec:
             limits:
               cpu: 100m
               memory: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
 ---
 # Expose Graphite ingestion port externally (Cilium LB-IPAM assigns a stable IP)
 # so TrueNAS can push metrics. Alloy scrapes the metrics port internally.

--- a/platform/base/node-cleanup/cronjob.yaml
+++ b/platform/base/node-cleanup/cronjob.yaml
@@ -81,10 +81,13 @@ spec:
                   memory: 128Mi
               securityContext:
                 allowPrivilegeEscalation: false
+                runAsNonRoot: true
                 capabilities:
                   drop:
                     - ALL
                 readOnlyRootFilesystem: true
+                seccompProfile:
+                  type: RuntimeDefault
               volumeMounts:
                 - name: tmp
                   mountPath: /tmp


### PR DESCRIPTION
## Summary
- Added `seccompProfile.type: RuntimeDefault` to 6 MCP server deployments (terraform, memory, cloudflare, kubernetes, grafana, stripe)
- Added full `securityContext` block to `graphite-exporter` deployment (was completely missing)
- Added `runAsNonRoot: true` and `seccompProfile.type: RuntimeDefault` to `node-cleanup` CronJob

All direct Kubernetes manifests now comply with the "restricted" Pod Security Standard, eliminating admission warnings like:
```
[Warning] policy pod-security-restricted/restricted fail. Validation rule 'restricted' failed.
```

## Test plan
- [ ] Verify pods restart without CrashLoopBackOff after deploy
- [ ] Confirm pod security admission warnings are gone from API server logs
- [ ] Spot-check that `graphite-exporter` still receives metrics from TrueNAS
- [ ] Verify MCP servers remain functional (health endpoints respond)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Enhanced security configurations for Cloudflare, Grafana, Kubernetes, Memory, Stripe, and Terraform services.
  * Strengthened container security hardening for graphite-exporter and node-cleanup services with additional protective measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->