### PR TITLE
feat(gpu): enable time-slicing for concurrent GPU workload scheduling (#671)

### DIFF
--- a/infrastructure/base/nvidia-device-plugin/helm-release.yaml
+++ b/infrastructure/base/nvidia-device-plugin/helm-release.yaml
@@ -9,7 +9,8 @@
 #
 # Time-slicing is enabled: each physical GPU is advertised as 4 virtual
 # GPUs, allowing multiple workloads (e.g. Ollama + JupyterHub) to share
-# a single GPU. No memory isolation — all slices share the full VRAM pool.
+# a single GPU. No memory or fault isolation — a crash in one workload
+# can take down all others on the same GPU.
 #
 # K3s auto-deployed this; kubeadm does not — hence this HelmRelease.
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -55,8 +56,8 @@ spec:
 
     # GPU time-slicing: advertise each physical GPU as 4 virtual GPUs.
     # Lets multiple workloads (Ollama + JupyterHub GPU notebooks) share
-    # one GPU via round-robin scheduling on the hardware.
-    # NOTE: no memory isolation — all slices share the full VRAM pool.
+    # one GPU via CUDA context switching.
+    # NOTE: no memory or fault isolation — all slices share the full VRAM pool.
     config:
       default: "time-slicing"
       map:


### PR DESCRIPTION
## Summary
- Enable NVIDIA GPU time-slicing in the device plugin, advertising each physical GPU as 4 virtual replicas
- Allows Ollama and JupyterHub GPU notebooks to share the single RTX 5070 Ti concurrently instead of one blocking the other
- No changes needed to Ollama or JupyterHub configs — `nvidia.com/gpu: 1` now maps to 1 time-slice automatically

## Details
- **Replicas: 4** — 1 for Ollama (always running) + up to 3 concurrent GPU notebooks
- **No memory isolation** — all slices share the full 16 GB VRAM pool. GPU OOM possible if total usage exceeds physical VRAM.
- **Rollout**: device plugin restarts (~30s). Running GPU pods are NOT evicted.

## Test plan
- [ ] Verify GPU node advertises 4 allocatable `nvidia.com/gpu`
- [ ] Verify Ollama remains running after device plugin restart
- [ ] Launch a GPU notebook in JupyterHub while Ollama is running
- [ ] Run `nvidia-smi` inside notebook to confirm both processes share the GPU

Closes #671

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU time-slicing capability has been enabled, allowing multiple concurrent workloads to efficiently share individual physical GPU resources. This feature improves cluster-wide GPU utilization by enabling flexible distribution of compute capacity across jobs. Workloads can now dynamically access GPU processing power without dedicated hardware assignment, resulting in improved infrastructure resource efficiency and better overall cluster throughput.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->