### PR TITLE
feat(crossplane): add Komoplane web UI with Traefik ingress (#674)

### DIFF
--- a/clusters/homelab/platform.yaml
+++ b/clusters/homelab/platform.yaml
@@ -59,6 +59,10 @@ spec:
       kind: HelmRelease
       name: reloader
       namespace: reloader
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: komoplane
+      namespace: crossplane-system
   dependsOn:
     - name: infrastructure
   postBuild:

--- a/infrastructure/base/flux-addons/helm-repositories.yaml
+++ b/infrastructure/base/flux-addons/helm-repositories.yaml
@@ -179,6 +179,16 @@ spec:
   interval: 24h
   url: https://falcosecurity.github.io/charts
 ---
+# Komodor — Komoplane (Crossplane visualisation dashboard)
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: komodorio
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://helm-charts.komodor.io
+---
 # Flux Operator — lifecycle manager and web UI for Flux CD
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository

--- a/platform/base/komoplane/helm-release.yaml
+++ b/platform/base/komoplane/helm-release.yaml
@@ -1,0 +1,49 @@
+# Komoplane — Crossplane resource visualisation and troubleshooting UI
+# https://github.com/komodorio/komoplane
+#
+# Deployed into crossplane-system alongside the Crossplane controller.
+# Exposed via Traefik at crossplane.${LAB_DOMAIN} with basic auth.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: komoplane
+  namespace: crossplane-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: komoplane
+      version: "*" # Lab: always use latest. Pin in production.
+      sourceRef:
+        kind: HelmRepository
+        name: komodorio
+        namespace: flux-system
+      interval: 1h
+  install:
+    timeout: 10m
+    remediation:
+      retries: 3
+  upgrade:
+    timeout: 10m
+    remediation:
+      retries: 3
+  values:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 2000
+      seccompProfile:
+        type: RuntimeDefault
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true

--- a/platform/base/komoplane/kustomization.yaml
+++ b/platform/base/komoplane/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/platform/base/network-policies/crossplane-system.yaml
+++ b/platform/base/network-policies/crossplane-system.yaml
@@ -45,6 +45,23 @@ spec:
             - port: "8080"
               protocol: TCP
 ---
+# Allow ingress from Traefik for Komoplane web UI
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: crossplane-system-allow-ingress-traefik
+  namespace: crossplane-system
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: traefik-system
+      toPorts:
+        - ports:
+            - port: "8090"
+              protocol: TCP
+---
 # Crossplane package downloads from Upbound registry.
 # NOTE: Add cloud provider API egress (AWS, GCP, Azure, etc.) when providers are deployed.
 apiVersion: cilium.io/v2

--- a/platform/base/traefik-config/external-services.yaml
+++ b/platform/base/traefik-config/external-services.yaml
@@ -150,6 +150,17 @@ spec:
   externalName: falco-falcosidekick-ui.falco-system.svc.cluster.local
 
 ---
+# ── Komoplane (in-cluster, crossplane-system namespace) ──────────
+apiVersion: v1
+kind: Service
+metadata:
+  name: komoplane-external
+  namespace: traefik-system
+spec:
+  type: ExternalName
+  externalName: komoplane.crossplane-system.svc.cluster.local
+
+---
 # ── Flux Operator WebUI (in-cluster, flux-system namespace) ─────
 apiVersion: v1
 kind: Service

--- a/platform/base/traefik-config/ingressroutes.yaml
+++ b/platform/base/traefik-config/ingressroutes.yaml
@@ -307,6 +307,28 @@ spec:
     certResolver: letsencrypt
 
 ---
+# ── Komoplane (in-cluster Crossplane dashboard) ──────────────────
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: komoplane
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`crossplane.${LAB_DOMAIN}`)
+      kind: Rule
+      services:
+        - name: komoplane-external
+          port: 8090
+      middlewares:
+        - name: security-headers
+        - name: dashboard-auth
+  tls:
+    certResolver: letsencrypt
+
+---
 # ── Falco UI (in-cluster runtime security dashboard) ────────────
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute

--- a/platform/homelab/crds/kustomization.yaml
+++ b/platform/homelab/crds/kustomization.yaml
@@ -20,6 +20,7 @@ resources:
   - ../../base/kube-state-metrics
   - ../../base/graphite-exporter
   - ../../base/backstage
+  - ../../base/komoplane
   - ../../base/traefik-config
   - ../../base/policy-reporter
   - ../../base/node-cleanup


### PR DESCRIPTION
## Summary

- Deploy [Komoplane](https://github.com/komodorio/komoplane) (Crossplane visualisation dashboard) into `crossplane-system` namespace via Flux HelmRelease with resource limits
- Expose at `crossplane.lab.kazie.co.uk` via Traefik IngressRoute with security headers and basic auth
- Add Komodor HelmRepository, ExternalName service, CiliumNetworkPolicy for Traefik ingress on port 8090, and Flux health check

## Test plan

- [ ] Verify Flux reconciles the new HelmRelease: `flux get helmreleases -A | grep komoplane`
- [ ] Confirm Komoplane pod is running: `kubectl -n crossplane-system get pods`
- [ ] Verify `crossplane.lab.kazie.co.uk` is accessible via HTTPS and prompts for basic auth
- [ ] Check network policy allows Traefik traffic: `kubectl -n crossplane-system get ciliumnetworkpolicies`

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Komoplane, a new interactive dashboard for visualizing and managing platform infrastructure resources with enhanced observability capabilities.
  * Deployed with secure, authenticated HTTPS access via automatic TLS certificate provisioning, network isolation, and security controls.
  * Provides real-time monitoring and relationship visualization of system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->