### PR TITLE
fix(gpu): add resource limits to chart initContainers for Kyverno compliance (#678)

### DIFF
--- a/infrastructure/base/nvidia-device-plugin/helm-release.yaml
+++ b/infrastructure/base/nvidia-device-plugin/helm-release.yaml
@@ -37,9 +37,13 @@ spec:
     timeout: 10m
     remediation:
       retries: 3
-  # The chart's config-manager initContainers (nvidia-device-plugin-init,
-  # mps-control-daemon-init) lack resource limits. Kyverno's
-  # require-resource-limits policy blocks the upgrade without these patches.
+  # The chart's config-manager init/sidecar containers lack resource limits.
+  # Kyverno's require-resource-limits policy blocks the upgrade without
+  # these patches. Affected containers (only rendered when config.map is set):
+  #   - nvidia-device-plugin-init      (initContainer, config-manager)
+  #   - nvidia-device-plugin-sidecar   (container, config watcher)
+  #   - mps-control-daemon-init        (initContainer, config-manager)
+  #   - mps-control-daemon-sidecar     (container, config watcher)
   postRenderers:
     - kustomize:
         patches:
@@ -63,6 +67,15 @@ spec:
                           limits:
                             cpu: 200m
                             memory: 128Mi
+                    containers:
+                      - name: nvidia-device-plugin-sidecar
+                        resources:
+                          requests:
+                            cpu: 50m
+                            memory: 64Mi
+                          limits:
+                            cpu: 200m
+                            memory: 128Mi
           - target:
               kind: DaemonSet
               name: nvidia-device-plugin-mps-control-daemon
@@ -76,6 +89,15 @@ spec:
                   spec:
                     initContainers:
                       - name: mps-control-daemon-init
+                        resources:
+                          requests:
+                            cpu: 50m
+                            memory: 64Mi
+                          limits:
+                            cpu: 200m
+                            memory: 128Mi
+                    containers:
+                      - name: mps-control-daemon-sidecar
                         resources:
                           requests:
                             cpu: 50m


### PR DESCRIPTION
## Summary

- The time-slicing config from #672 failed to deploy because the NVIDIA device plugin chart (v0.18.2) has `config-manager` initContainers without resource limits
- Kyverno's `require-resource-limits` policy blocked the Helm upgrade, causing rollback to the pre-time-slicing config — leaving only 1 GPU (held by Ollama), so JupyterHub GPU notebooks can't schedule
- Adds Flux `postRenderers` to patch `nvidia-device-plugin-init` and `mps-control-daemon-init` initContainers with resource limits

## Test plan

- [ ] Verify Flux reconciles the HelmRelease successfully (`flux get hr -n nvidia-device-plugin`)
- [ ] Confirm ConfigMap is created in `nvidia-device-plugin` namespace
- [ ] Check GPU node advertises 4 virtual GPUs (`kubectl describe node -l node.kubernetes.io/gpu=true | grep nvidia.com/gpu`)
- [ ] Launch a JupyterHub GPU notebook and confirm it schedules

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added resource requests and limits for NVIDIA device plugin init and sidecar containers, preventing upgrade failures and improving stability during deployment.

* **Chores**
  * Updated infrastructure configuration to enforce consistent CPU and memory allocation across NVIDIA device plugin components for policy compliance and predictable resource usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->