### PR TITLE
fix(ci): add SA token mount and diagnostics for runner API check (#685)

### DIFF
--- a/.github/workflows/cluster-health-gate.yaml
+++ b/.github/workflows/cluster-health-gate.yaml
@@ -40,14 +40,15 @@ jobs:
           set -euo pipefail
           HEALTHY=true
 
-          # Diagnostic: show in-cluster config availability
+          # Verify in-cluster config before attempting kubectl calls
           echo "KUBERNETES_SERVICE_HOST=${KUBERNETES_SERVICE_HOST:-<unset>}"
           echo "KUBERNETES_SERVICE_PORT=${KUBERNETES_SERVICE_PORT:-<unset>}"
-          if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
-            echo "SA token: mounted"
-          else
-            echo "::warning::SA token NOT mounted — kubectl cannot authenticate in-cluster"
+          if [ ! -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+            echo "::error::SA token NOT mounted — kubectl cannot authenticate in-cluster. Ensure automountServiceAccountToken is true in the runner pod spec."
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "SA token: mounted"
 
           # 1. API server reachable
           if ! kubectl cluster-info --request-timeout=10s 2>&1; then

--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -41,17 +41,21 @@ jobs:
       - name: Pre-flight — API server reachable
         id: preflight
         run: |
-          # Diagnostic: show in-cluster config availability
+          set -euo pipefail
+
+          # Verify in-cluster config before attempting kubectl calls
           echo "KUBERNETES_SERVICE_HOST=${KUBERNETES_SERVICE_HOST:-<unset>}"
           echo "KUBERNETES_SERVICE_PORT=${KUBERNETES_SERVICE_PORT:-<unset>}"
-          if [ -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
-            echo "SA token: mounted"
-          else
-            echo "::warning::SA token NOT mounted — kubectl cannot authenticate in-cluster"
+          if [ ! -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+            echo "::error::SA token NOT mounted — kubectl cannot authenticate in-cluster. Ensure automountServiceAccountToken is true in the runner pod spec."
+            echo "api_reachable=false" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
+          echo "SA token: mounted"
 
           for i in 1 2 3 4 5; do
             if kubectl cluster-info --request-timeout=10s 2>&1; then
+              echo "API server reachable"
               echo "api_reachable=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
@@ -105,9 +105,9 @@ spec:
     template:
       spec:
         serviceAccountName: arc-runner-flux-reader
-        # Required for kubectl to authenticate against the API server.
-        # Without this, the in-cluster config has no token and health
-        # check workflows fail with "API server unreachable".
+        # ARC's runner scale set disables SA token mounting by default
+        # for security. We re-enable it because health-check workflows
+        # need in-cluster kubectl access via the arc-runner-flux-reader SA.
         automountServiceAccountToken: true
         # Security hardening — runners execute workflow code, so isolate them.
         # The official runner image runs as UID 1001 (runner user) by default.

--- a/platform/base/network-policies/arc-runners.yaml
+++ b/platform/base/network-policies/arc-runners.yaml
@@ -40,8 +40,10 @@ spec:
             - port: "443"
               protocol: TCP
 ---
-# Workflow steps download CLI tools at runtime (kubectl from dl.k8s.io,
-# Flux CLI from fluxcd.io). dl.k8s.io redirects to storage.googleapis.com.
+# Workflow steps download CLI tools at runtime: kubectl from dl.k8s.io
+# (Fastly CDN; storage.googleapis.com kept as fallback), Flux install
+# script from fluxcd.io (binary itself comes from GitHub releases,
+# covered by the github egress policy above).
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:


### PR DESCRIPTION
## Summary

- Add `automountServiceAccountToken: true` to runner pod spec — without this, kubectl has no in-cluster credentials and every API check fails instantly
- Remove stderr suppression (`> /dev/null 2>&1`) from `kubectl cluster-info` so the actual error is visible in workflow logs
- Add diagnostic output (KUBERNETES_SERVICE_HOST, SA token mount status) to both post-deploy-check and cluster-health-gate
- Add missing FQDNs (dl.k8s.io, storage.googleapis.com, fluxcd.io) to arc-runners network policy for when audit mode is turned off

## Context

The post-deploy health check has **never succeeded** — all ~40 runs since March 4 fail at the API server reachability check. The error was completely invisible because stderr was suppressed.

Closes #685

## Test plan

- [ ] Merge and verify the next post-deploy check run shows diagnostic output
- [ ] Confirm SA token is mounted (`SA token: mounted` in logs)
- [ ] Confirm `kubectl cluster-info` succeeds or shows a meaningful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added network policy to allow CLI/tool downloads from external package hosts.

* **Improvements**
  * Added in-cluster configuration and service account token presence checks to diagnostics.
  * Made API reachability checks preserve command output for better visibility.
  * Enabled service account token mounting for in-cluster authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->