### PR TITLE
fix(ci): build kubeconfig from SA creds — kubectl defaults to localhost:8080 (#685)

### DIFF
--- a/.github/workflows/cluster-health-gate.yaml
+++ b/.github/workflows/cluster-health-gate.yaml
@@ -34,21 +34,31 @@ jobs:
             echo "kubectl already available: $(kubectl version --client)"
           fi
 
+      - name: Configure in-cluster kubectl
+        run: |
+          set -euo pipefail
+          if [ -z "${KUBERNETES_SERVICE_HOST:-}" ] || [ -z "${KUBERNETES_SERVICE_PORT:-}" ]; then
+            echo "::error::KUBERNETES_SERVICE_HOST/PORT not set — is the runner running inside the cluster?"
+            exit 1
+          fi
+          if [ ! -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+            echo "::error::SA token NOT mounted — ensure automountServiceAccountToken is true in the runner pod spec."
+            exit 1
+          fi
+          kubectl config set-cluster k8s \
+            --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+            --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl config set-credentials runner \
+            --token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+          kubectl config set-context default --cluster=k8s --user=runner
+          kubectl config use-context default
+          echo "Configured kubectl → https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+
       - name: Check cluster health
         id: check
         run: |
           set -euo pipefail
           HEALTHY=true
-
-          # Verify in-cluster config before attempting kubectl calls
-          echo "KUBERNETES_SERVICE_HOST=${KUBERNETES_SERVICE_HOST:-<unset>}"
-          echo "KUBERNETES_SERVICE_PORT=${KUBERNETES_SERVICE_PORT:-<unset>}"
-          if [ ! -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
-            echo "::error::SA token NOT mounted — kubectl cannot authenticate in-cluster. Ensure automountServiceAccountToken is true in the runner pod spec."
-            echo "healthy=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "SA token: mounted"
 
           # 1. API server reachable
           if ! kubectl cluster-info --request-timeout=10s 2>&1; then

--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -38,21 +38,33 @@ jobs:
             echo "kubectl already available: $(kubectl version --client)"
           fi
 
+      - name: Configure in-cluster kubectl
+        run: |
+          set -euo pipefail
+          # kubectl ignores in-cluster config when any kubeconfig exists.
+          # The runner image ships a default ~/.kube/config that points to
+          # localhost:8080, so we must build one from the mounted SA creds.
+          if [ -z "${KUBERNETES_SERVICE_HOST:-}" ] || [ -z "${KUBERNETES_SERVICE_PORT:-}" ]; then
+            echo "::error::KUBERNETES_SERVICE_HOST/PORT not set — is the runner running inside the cluster?"
+            exit 1
+          fi
+          if [ ! -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
+            echo "::error::SA token NOT mounted — ensure automountServiceAccountToken is true in the runner pod spec."
+            exit 1
+          fi
+          kubectl config set-cluster k8s \
+            --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+            --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl config set-credentials runner \
+            --token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+          kubectl config set-context default --cluster=k8s --user=runner
+          kubectl config use-context default
+          echo "Configured kubectl → https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+
       - name: Pre-flight — API server reachable
         id: preflight
         run: |
           set -euo pipefail
-
-          # Verify in-cluster config before attempting kubectl calls
-          echo "KUBERNETES_SERVICE_HOST=${KUBERNETES_SERVICE_HOST:-<unset>}"
-          echo "KUBERNETES_SERVICE_PORT=${KUBERNETES_SERVICE_PORT:-<unset>}"
-          if [ ! -f /var/run/secrets/kubernetes.io/serviceaccount/token ]; then
-            echo "::error::SA token NOT mounted — kubectl cannot authenticate in-cluster. Ensure automountServiceAccountToken is true in the runner pod spec."
-            echo "api_reachable=false" >> "$GITHUB_OUTPUT"
-            exit 1
-          fi
-          echo "SA token: mounted"
-
           for i in 1 2 3 4 5; do
             if kubectl cluster-info --request-timeout=10s 2>&1; then
               echo "API server reachable"


### PR DESCRIPTION
## Summary

- kubectl in the runner pod was connecting to `localhost:8080` instead of the cluster API at `10.96.0.1:443`
- The runner image ships a default kubeconfig that overrides in-cluster auto-detection
- Fix: add a "Configure in-cluster kubectl" step that builds a kubeconfig from the mounted SA token + CA cert before any kubectl/flux commands

## Evidence from diagnostic run

```
KUBERNETES_SERVICE_HOST=10.96.0.1
KUBERNETES_SERVICE_PORT=443
SA token: mounted
The connection to the server localhost:8080 was refused
```

SA token is mounted (previous PR fixed that), env vars are set, but kubectl ignores them because it prefers kubeconfig files over in-cluster config.

Follows up on #685 / PR #686

## Test plan

- [ ] Merge and verify the next post-deploy check connects to `10.96.0.1:443`
- [ ] Confirm "API server reachable" appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)