### PR TITLE
chore(arc): clarify automountServiceAccountToken comment (#685)

### DIFF
--- a/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
+++ b/infrastructure/base/github-actions-runner/helm-release-runner-set.yaml
@@ -105,9 +105,11 @@ spec:
     template:
       spec:
         serviceAccountName: arc-runner-flux-reader
-        # ARC's runner scale set disables SA token mounting by default
-        # for security. We re-enable it because health-check workflows
-        # need in-cluster kubectl access via the arc-runner-flux-reader SA.
+        # ARC disables SA token mounting by default for security.
+        # Re-enabled so health-check workflows can build a kubeconfig
+        # from the mounted SA creds (the runner image ships a default
+        # ~/.kube/config pointing to localhost:8080, which overrides
+        # in-cluster auto-detection).
         automountServiceAccountToken: true
         # Security hardening — runners execute workflow code, so isolate them.
         # The official runner image runs as UID 1001 (runner user) by default.


### PR DESCRIPTION
## Summary
- Updates the comment on `automountServiceAccountToken` to explain the actual root cause (runner image's default kubeconfig pointing to localhost:8080)
- Triggers the post-deploy health check with the kubeconfig fix from #687

## Test plan
- [ ] Post-deploy health check passes after merge — `kubectl cluster-info` connects to `10.96.0.1:443` instead of `localhost:8080`

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)