### PR TITLE
fix(ci): use /healthz for API reachability check (#685)

### DIFF
--- a/.github/workflows/cluster-health-gate.yaml
+++ b/.github/workflows/cluster-health-gate.yaml
@@ -61,7 +61,7 @@ jobs:
           HEALTHY=true
 
           # 1. API server reachable
-          if ! kubectl cluster-info --request-timeout=10s 2>&1; then
+          if ! kubectl get --raw /healthz --request-timeout=10s 2>&1; then
             echo "::error::API server unreachable"
             echo "healthy=false" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           set -euo pipefail
           for i in 1 2 3 4 5; do
-            if kubectl cluster-info --request-timeout=10s 2>&1; then
+            if kubectl get --raw /healthz --request-timeout=10s 2>&1; then
               echo "API server reachable"
               echo "api_reachable=true" >> "$GITHUB_OUTPUT"
               exit 0

--- a/infrastructure/base/github-actions-runner/rbac-flux-reader.yaml
+++ b/infrastructure/base/github-actions-runner/rbac-flux-reader.yaml
@@ -22,8 +22,8 @@ rules:
   - apiGroups: [""]
     resources: ["pods", "nodes"]
     verbs: ["get", "list"]
-  # kubectl cluster-info needs access to /api and /version
-  - nonResourceURLs: ["/api", "/api/*", "/version"]
+  # Health checks and API discovery
+  - nonResourceURLs: ["/healthz", "/api", "/api/*", "/version"]
     verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Summary
- Replace `kubectl cluster-info` with `kubectl get --raw /healthz` in both workflow files
- `cluster-info` lists services in `kube-system` which the SA can't do (Forbidden)
- `/healthz` only needs non-resource URL access — added to RBAC
- The API **is** reachable; the previous check was just using the wrong command

## Context
After PRs #686 (SA token mount) and #687 (kubeconfig fix), the runner correctly connects to `10.96.0.1:443`. But `kubectl cluster-info` fails with:
```
Error from server (Forbidden): services is forbidden: User "system:serviceaccount:arc-runners:arc-runner-flux-reader" cannot list resource "services" in API group "" in the namespace "kube-system"
```

## Test plan
- [ ] Post-deploy health check passes the pre-flight API check after merge

Ref #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)