### PR TITLE
fix(crossplane): escape ${path.module} for Flux envsubst (#690)

### DIFF
--- a/infrastructure/base/crossplane-provider-neon/provider-config.yaml
+++ b/infrastructure/base/crossplane-provider-neon/provider-config.yaml
@@ -44,7 +44,7 @@ spec:
       }
     }
     provider "neon" {
-      api_key = file("${path.module}/neon-api-key.txt")
+      api_key = file("$${path.module}/neon-api-key.txt")
     }
   credentials:
     - filename: neon-api-key.txt

--- a/infrastructure/base/crossplane-provider-supabase/provider-config.yaml
+++ b/infrastructure/base/crossplane-provider-supabase/provider-config.yaml
@@ -43,7 +43,7 @@ spec:
       }
     }
     provider "supabase" {
-      access_token = file("${path.module}/supabase-token.txt")
+      access_token = file("$${path.module}/supabase-token.txt")
     }
   credentials:
     - filename: supabase-token.txt


### PR DESCRIPTION
## Summary
- Escape `${path.module}` as `$${path.module}` in the Neon and Supabase Crossplane ProviderConfig manifests so Flux's envsubst doesn't try to parse it as a variable (the dot breaks envsubst, causing "missing closing brace")
- This was the root cause of all post-deploy health check failures since #677 merged — the `infrastructure` Kustomization couldn't reconcile

## Test plan
- [ ] Post-deploy health check passes after merge
- [ ] `infrastructure` Kustomization shows `Ready: True` in cluster

Closes #690

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated provider configuration files for Neon and Supabase to correct variable handling and processing during infrastructure deployment. These maintenance fixes ensure consistent and reliable processing of provider configuration settings across all deployment environments, improving the overall stability and predictability of infrastructure provisioning operations while reducing potential configuration-related deployment issues and inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->