### PR TITLE
fix(crossplane): add required selector to DeploymentRuntimeConfig (#696)

### DIFF
--- a/infrastructure/base/crossplane/deployment-runtime-config.yaml
+++ b/infrastructure/base/crossplane/deployment-runtime-config.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   deploymentTemplate:
     spec:
+      selector:
+        matchLabels: {}
       template:
         spec:
           containers:


### PR DESCRIPTION
## Summary

- Add required `selector` field to DeploymentRuntimeConfig to pass Flux server-side dry-run validation

Follows on from PR #698 which added the DRC but was missing the required `spec.deploymentTemplate.spec.selector` field. Crossplane overrides this when creating actual provider Deployments, but the API validation requires it.

## Test plan

- [ ] infrastructure-crds dry-run passes
- [ ] All providers reach HEALTHY=True
- [ ] Full chain reconciles

🤖 Generated with [Claude Code](https://claude.ai/code)