### PR TITLE
fix(platform): add force annotation to immutable init Job (#708)

### DIFF
--- a/platform/base/backstage/neon-secret-sync.yaml
+++ b/platform/base/backstage/neon-secret-sync.yaml
@@ -85,7 +85,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: backstage
     app.kubernetes.io/managed-by: flux
+  annotations:
+    # Jobs are immutable — Flux must force-replace on spec changes (e.g. image bumps)
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
+  ttlSecondsAfterFinished: 600
   backoffLimit: 5
   template:
     metadata:


### PR DESCRIPTION
## Summary

- Add `kustomize.toolkit.fluxcd.io/force: enabled` annotation to the `neon-secret-sync-init` Job so Flux can force-replace it on spec changes (e.g., Renovate image bumps)
- Add `ttlSecondsAfterFinished: 600` so completed Jobs are garbage-collected automatically

Without the force annotation, Kubernetes rejects updates to the immutable Job spec, blocking the entire `platform-crds` Kustomization.

Closes #708

## Test plan

- [ ] Verify `platform-crds` Kustomization reconciles successfully
- [ ] Verify init Job completes and is cleaned up after 10 minutes

🤖 Generated with [Claude Code](https://claude.ai/code)