### PR TITLE
fix(platform): unblock Neon credential bootstrap reconciliation (#708)

### DIFF
--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -28,10 +28,12 @@ spec:
       name: neon-backstage-credentials
       valuesKey: database_host
       targetPath: backstage.appConfig.backend.database.connection.host
+      optional: true
     - kind: Secret
       name: neon-backstage-credentials
       valuesKey: database_password
       targetPath: backstage.appConfig.backend.database.connection.password
+      optional: true
 
   values:
     backstage:

--- a/platform/base/backstage/neon-secret-sync.yaml
+++ b/platform/base/backstage/neon-secret-sync.yaml
@@ -85,7 +85,11 @@ metadata:
   labels:
     app.kubernetes.io/part-of: backstage
     app.kubernetes.io/managed-by: flux
+  annotations:
+    # Jobs are immutable — Flux must force-replace on spec changes (e.g. image bumps)
+    kustomize.toolkit.fluxcd.io/force: enabled
 spec:
+  ttlSecondsAfterFinished: 600
   backoffLimit: 5
   template:
     metadata:


### PR DESCRIPTION
## Summary

Fixes two issues blocking `platform-crds` reconciliation after #707:

- **Immutable Job**: Re-adds `kustomize.toolkit.fluxcd.io/force: enabled` and `ttlSecondsAfterFinished: 600` to the init Job (reverted by auto-rollback in previous attempt)
- **valuesFrom race condition**: Adds `optional: true` to both `valuesFrom` entries on the Backstage HelmRelease. Without this, the HelmRelease enters `ValuesError` if `neon-backstage-credentials` doesn't exist yet (init Job hasn't completed), which fails the `platform-crds` health check and blocks the entire reconciliation chain.

Closes #708

## Test plan

- [ ] `platform-crds` Kustomization reconciles to Ready
- [ ] Backstage HelmRelease becomes Ready after init Job completes
- [ ] Post-deploy health check passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Database host and password credential mappings are now optional, allowing flexible configuration scenarios.
  * Automatic cleanup of completed background jobs after 10 minutes reduces infrastructure resource footprint.
  * Enhanced deployment process with improved handling of configuration changes and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->