### PR TITLE
fix(platform): remove Backstage from platform-crds health checks (#708)

### DIFF
--- a/clusters/homelab/platform.yaml
+++ b/clusters/homelab/platform.yaml
@@ -47,10 +47,9 @@ spec:
       kind: HelmRelease
       name: kube-state-metrics
       namespace: monitoring
-    - apiVersion: helm.toolkit.fluxcd.io/v2
-      kind: HelmRelease
-      name: backstage
-      namespace: backstage
+    # Backstage excluded from healthChecks: on bootstrap, the neon-secret-sync
+    # CronJob needs time to copy DB credentials before Backstage can start.
+    # The post-deploy workflow checks all HelmReleases independently.
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: policy-reporter


### PR DESCRIPTION
## Summary

Removes the Backstage HelmRelease from `platform-crds` health checks to break a circular dependency:

1. `platform-crds` applies the neon-secret-sync CronJob + Backstage HelmRelease
2. Backstage can't start without DB credentials (no `neon-backstage-credentials` secret yet)
3. The CronJob creates the secret, but Backstage health check blocks `platform-crds` from becoming Ready
4. Everything downstream (`platform` → `apps`) is blocked

The post-deploy workflow already checks all HelmReleases independently, so Backstage health is still monitored.

Closes #708

## Test plan

- [ ] `platform-crds` Kustomization reconciles to Ready without waiting for Backstage
- [ ] Backstage self-heals after CronJob creates the credentials secret
- [ ] Post-deploy health check passes

🤖 Generated with [Claude Code](https://claude.ai/code)