### PR TITLE
fix(crossplane): remove duplicate required_providers from Neon workspace (#714)

### DIFF
--- a/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
+++ b/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
@@ -29,15 +29,6 @@ spec:
   forProvider:
     source: Inline
     module: |
-      terraform {
-        required_providers {
-          neon = {
-            source  = "kislerdm/neon"
-            version = "~> 0.6"
-          }
-        }
-      }
-
       resource "neon_project" "backstage" {
         name       = "backstage"
         region_id  = "aws-eu-west-2"


### PR DESCRIPTION
## Summary
- Removes the duplicate `terraform { required_providers { ... } }` block from the Neon Backstage Workspace inline module
- The `ProviderConfig` (`neon-default`) already declares the `kislerdm/neon` provider — the duplicate caused Terraform init to fail, blocking DB provisioning and cascading into Backstage HelmRelease failure

## Post-merge
Delete the failed init Job so Flux recreates it:
```
kubectl delete job neon-secret-sync-init -n backstage
```

## Test plan
- [ ] Crossplane Workspace `neon-backstage` reconciles successfully
- [ ] Secret `neon-backstage-outputs` is created in `crossplane-system`
- [ ] `neon-secret-sync-init` Job completes and creates `neon-backstage-credentials` in `backstage`
- [ ] Backstage HelmRelease becomes Ready

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored internal infrastructure configuration for database provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->