### PR TITLE
fix(crossplane): add org_id to Neon workspace (#714)

### DIFF
--- a/clusters/homelab/vars.yaml
+++ b/clusters/homelab/vars.yaml
@@ -97,6 +97,7 @@ data:
   OP_ITEM_AZURE_SP: "crossplane-azure-service-principal"
   OP_ITEM_OCI_CREDS: "crossplane-oci-credentials"
   OP_ITEM_NEON_API_KEY: "crossplane-neon-api-key"
+  NEON_ORG_ID: "org-hidden-glade-59843512"
   OP_ITEM_SUPABASE_TOKEN: "crossplane-supabase-access-token"
   GCP_PROJECT_ID: "homelab-489415"
   AWS_CROSSPLANE_ROLE_ARN: "arn:aws:iam::677130120263:role/crossplane-homelab"

--- a/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
+++ b/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
@@ -31,6 +31,7 @@ spec:
     module: |
       resource "neon_project" "backstage" {
         name       = "backstage"
+        org_id     = "${NEON_ORG_ID}"
         region_id  = "aws-eu-west-2"
         pg_version = 16
 


### PR DESCRIPTION
## Summary
- Adds `NEON_ORG_ID` variable to cluster vars
- References it in the Neon Backstage workspace inline module via `org_id = "${NEON_ORG_ID}"`
- Neon API now requires `org_id` on `neon_project` resources — without it, Terraform apply fails with `org_id is required`

## Post-merge
After Flux reconciles, the Crossplane workspace should provision the Neon database, which triggers the secret sync, which unblocks the Backstage HelmRelease.

## Test plan
- [ ] Crossplane Workspace `neon-backstage` reconciles without error
- [ ] Secret `neon-backstage-outputs` created in `crossplane-system`
- [ ] `neon-secret-sync` Job copies credentials to `backstage` namespace
- [ ] Backstage HelmRelease becomes Ready

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)