### PR TITLE
fix(crossplane): add org_id and suspend Backstage during Neon bootstrap (#714)

### DIFF
--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -149,7 +149,8 @@ jobs:
             fi
             # Exclude nvidia-device-plugin: its DaemonSet needs a GPU node
             # with node.kubernetes.io/gpu=true label — schedules 0 pods otherwise
-            NOT_READY=$(echo "$FLUX_OUTPUT" | grep -v "nvidia-device-plugin" | grep -v "True" || true)
+            # Exclude backstage: suspended while Neon DB provisions via Crossplane
+            NOT_READY=$(echo "$FLUX_OUTPUT" | grep -v "nvidia-device-plugin" | grep -v "backstage" | grep -v "True" || true)
             if [ -z "$NOT_READY" ]; then
               echo "All HelmReleases are Ready"
               flux get helmreleases -A

--- a/clusters/homelab/vars.yaml
+++ b/clusters/homelab/vars.yaml
@@ -97,6 +97,7 @@ data:
   OP_ITEM_AZURE_SP: "crossplane-azure-service-principal"
   OP_ITEM_OCI_CREDS: "crossplane-oci-credentials"
   OP_ITEM_NEON_API_KEY: "crossplane-neon-api-key"
+  NEON_ORG_ID: "org-hidden-glade-59843512"
   OP_ITEM_SUPABASE_TOKEN: "crossplane-supabase-access-token"
   GCP_PROJECT_ID: "homelab-489415"
   AWS_CROSSPLANE_ROLE_ARN: "arn:aws:iam::677130120263:role/crossplane-homelab"

--- a/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
+++ b/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
@@ -31,6 +31,7 @@ spec:
     module: |
       resource "neon_project" "backstage" {
         name       = "backstage"
+        org_id     = "${NEON_ORG_ID}"
         region_id  = "aws-eu-west-2"
         pg_version = 16
 

--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -4,6 +4,7 @@ metadata:
   name: backstage
   namespace: backstage
 spec:
+  suspend: true
   interval: 30m
   chart:
     spec:


### PR DESCRIPTION
## Summary
- Adds `NEON_ORG_ID` to cluster vars and references it in the Neon workspace (`org_id` is now required by the Neon API)
- Suspends Backstage HelmRelease while Crossplane provisions the Neon DB
- Excludes Backstage from the post-deploy HelmRelease health check to prevent auto-rollback during bootstrap

## Why suspend?
The full provisioning chain (Crossplane → Terraform apply → secret sync → Backstage start) takes longer than the 10-minute post-deploy timeout. Suspending Backstage lets the org_id fix deploy without triggering a rollback.

## Follow-up
Once Crossplane provisions the Neon DB and credentials are synced, a follow-up PR will unsuspend Backstage and re-add it to the post-deploy check.

## Test plan
- [ ] Post-deploy check passes (Backstage excluded)
- [ ] Crossplane Workspace `neon-backstage` reconciles without error
- [ ] Secret `neon-backstage-outputs` created in `crossplane-system`

Closes #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified post-deployment check filters to exclude backstage from readiness validation
  * Added Neon organization ID configuration
  * Updated backstage service reconciliation settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->