### PR TITLE
fix(crossplane): remove suspend_timeout not allowed on free tier (#714)

### DIFF
--- a/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
+++ b/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
@@ -41,9 +41,6 @@ spec:
         }
 
         default_endpoint_settings {
-          # At least equal to Backstage catalog sync interval (600s) to
-          # avoid cold starts on every sync cycle.
-          suspend_timeout_seconds  = 600
           autoscaling_limit_min_cu = 0.25
           autoscaling_limit_max_cu = 1
         }


### PR DESCRIPTION
## Summary
- Removes `suspend_timeout_seconds = 600` from Neon workspace — this setting is not permitted on the free tier and causes `[HTTP Code: 412] modifying the suspend interval is not permitted on this account`

## Test plan
- [ ] Crossplane Workspace `neon-backstage` provisions without error
- [ ] Secret `neon-backstage-outputs` populated with valid credentials

Ref #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)