### PR TITLE
fix(crossplane): set history_retention_seconds for Neon free tier (#714)

### DIFF
--- a/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
+++ b/infrastructure/base/crossplane-neon-databases/backstage/workspace.yaml
@@ -30,10 +30,11 @@ spec:
     source: Inline
     module: |
       resource "neon_project" "backstage" {
-        name       = "backstage"
-        org_id     = "${NEON_ORG_ID}"
-        region_id  = "aws-eu-west-2"
-        pg_version = 16
+        name                      = "backstage"
+        org_id                    = "${NEON_ORG_ID}"
+        region_id                 = "aws-eu-west-2"
+        pg_version                = 16
+        history_retention_seconds = 21600
 
         branch {
           database_name = "backstage"


### PR DESCRIPTION
## Summary
- Sets `history_retention_seconds = 21600` on the Neon project resource
- Free tier caps at 21600 (6h), but the provider defaults to 86400 (24h), causing a `400` error

## Test plan
- [ ] Crossplane Workspace `neon-backstage` provisions without error

Ref #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)