### PR TITLE
fix: resolve unhealthy pods — falco redis OOM and backstage suspended (#721)

### DIFF
--- a/.github/workflows/post-deploy-check.yaml
+++ b/.github/workflows/post-deploy-check.yaml
@@ -149,8 +149,7 @@ jobs:
             fi
             # Exclude nvidia-device-plugin: its DaemonSet needs a GPU node
             # with node.kubernetes.io/gpu=true label — schedules 0 pods otherwise
-            # Exclude backstage: suspended while Neon DB provisions via Crossplane
-            NOT_READY=$(echo "$FLUX_OUTPUT" | grep -v "nvidia-device-plugin" | grep -v "backstage" | grep -v "True" || true)
+            NOT_READY=$(echo "$FLUX_OUTPUT" | grep -v "nvidia-device-plugin" | grep -v "True" || true)
             if [ -z "$NOT_READY" ]; then
               echo "All HelmReleases are Ready"
               flux get helmreleases -A

--- a/infrastructure/base/falco/helm-release.yaml
+++ b/infrastructure/base/falco/helm-release.yaml
@@ -156,7 +156,7 @@ spec:
           resources:
             requests:
               cpu: 50m
-              memory: 64Mi
+              memory: 256Mi
             limits:
               cpu: 100m
-              memory: 128Mi
+              memory: 512Mi

--- a/platform/base/backstage/helm-release.yaml
+++ b/platform/base/backstage/helm-release.yaml
@@ -4,7 +4,7 @@ metadata:
   name: backstage
   namespace: backstage
 spec:
-  suspend: true
+  suspend: false
   interval: 30m
   chart:
     spec:


### PR DESCRIPTION
## Summary
- **Falco Redis OOMKilled**: `redis/redis-stack:7.2.0-v11` loads heavy modules (RediSearch, RedisTimeSeries, RedisJSON, RedisBloom, RedisGears) exceeding 128Mi. Bumped to 256Mi requests / 512Mi limits.
- **Backstage suspended**: Neon credentials are now synced via Crossplane. Unsuspend the HelmRelease.
- **Post-deploy checks**: Removed backstage exclusion from HelmRelease health checks since it's no longer suspended.

Closes #721

## Test plan
- [ ] Verify `falco-falcosidekick-ui-redis-0` starts without OOMKill
- [ ] Verify backstage pods reach Running state with Neon DB connection
- [ ] Verify post-deploy health check passes with backstage included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-deployment monitoring configuration to include the backstage service in readiness and health status verification processes
  * Increased memory resource limits for the Falcosidekick Redis container to enhance system stability and operational resilience
  * Enabled the backstage service, transitioning it from suspended to active deployment state for full platform integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->